### PR TITLE
[odla_dnnl] fix gemm bias fusion

### DIFF
--- a/ODLA/platforms/dnnl/odla_dnnl.cc
+++ b/ODLA/platforms/dnnl/odla_dnnl.cc
@@ -1304,7 +1304,6 @@ odla_value odla_Gemm(odla_value lhs, odla_bool transpose_lhs, odla_value rhs,
   auto lhs_mem = dnnl::memory(lhs_md, g_comp->eng, lhs->mem.get_data_handle());
   auto rhs_mem = dnnl::memory(rhs_md, g_comp->eng, rhs->mem.get_data_handle());
   bool is_elements_add = false;
-  
   if (bias) {
     auto bias_elements = GetTotalElements(bias->shape);
     if (bias_elements == N) {
@@ -1318,11 +1317,10 @@ odla_value odla_Gemm(odla_value lhs, odla_bool transpose_lhs, odla_value rhs,
                     {DNNL_ARG_WEIGHTS, rhs_mem},
                     {DNNL_ARG_BIAS, bias_mem},
                     {DNNL_ARG_DST, ret_mem}});
-    }
-    else if(bias_elements == 1) {
+    } else if (bias_elements == 1) {
       dnnl::post_ops ops;
       dnnl::primitive_attr gemm_attr;
-      float beta = ((float *)bias->mem.get_data_handle())[0];
+      float beta = ((float*)bias->mem.get_data_handle())[0];
       ops.append_eltwise(1.f, dnnl::algorithm::eltwise_linear, 0.f, beta);
       gemm_attr.set_post_ops(ops);
       dnnl::matmul::desc md(lhs_md, rhs_md, ret_md);
@@ -1331,8 +1329,8 @@ odla_value odla_Gemm(odla_value lhs, odla_bool transpose_lhs, odla_value rhs,
       add_op(prim, {{DNNL_ARG_SRC, rhs_mem},
                     {DNNL_ARG_WEIGHTS, rhs_mem},
                     {DNNL_ARG_DST, ret_mem}});
-    } else 
-        is_elements_add = true;
+    } else
+      is_elements_add = true;
   } else {
     dnnl::matmul::desc md(lhs_md, rhs_md, ret_md);
     dnnl::matmul::primitive_desc pd(md, g_comp->eng);
@@ -1342,13 +1340,14 @@ odla_value odla_Gemm(odla_value lhs, odla_bool transpose_lhs, odla_value rhs,
                   {DNNL_ARG_DST, ret_mem}});
   }
 
-  odla_value v = CreateValue(ret_mem, output_dims, is_elements_add ? nullptr : id);
+  odla_value v =
+      CreateValue(ret_mem, output_dims, is_elements_add ? nullptr : id);
 
   InterpretIfNeeded();
 
   return is_elements_add ? odla_Add(v, bias, id) : v;
 }
-  
+
 odla_value odla_Erf(odla_value input, const odla_value_id value_id) {
   std::function<void()> op;
   const auto& input_shape = input->shape;

--- a/ODLA/platforms/dnnl/odla_dnnl.cc
+++ b/ODLA/platforms/dnnl/odla_dnnl.cc
@@ -1303,17 +1303,36 @@ odla_value odla_Gemm(odla_value lhs, odla_bool transpose_lhs, odla_value rhs,
   auto ret_mem = dnnl::memory(ret_md, g_comp->eng);
   auto lhs_mem = dnnl::memory(lhs_md, g_comp->eng, lhs->mem.get_data_handle());
   auto rhs_mem = dnnl::memory(rhs_md, g_comp->eng, rhs->mem.get_data_handle());
+  bool is_elements_add = false;
+  
   if (bias) {
-    dnnl::memory::desc bias_md({1, N}, dt, dnnl::memory::format_tag::ab);
-    auto bias_mem =
-        dnnl::memory(bias_md, g_comp->eng, bias->mem.get_data_handle());
-    dnnl::matmul::desc md(lhs_md, rhs_md, bias_md, ret_md);
-    dnnl::matmul::primitive_desc pd(md, g_comp->eng);
-    dnnl::primitive prim = dnnl::matmul(pd);
-    add_op(prim, {{DNNL_ARG_SRC, rhs_mem},
-                  {DNNL_ARG_WEIGHTS, rhs_mem},
-                  {DNNL_ARG_BIAS, bias_mem},
-                  {DNNL_ARG_DST, ret_mem}});
+    auto bias_elements = GetTotalElements(bias->shape);
+    if (bias_elements == N) {
+      dnnl::memory::desc bias_md({1, N}, dt, dnnl::memory::format_tag::ab);
+      auto bias_mem =
+          dnnl::memory(bias_md, g_comp->eng, bias->mem.get_data_handle());
+      dnnl::matmul::desc md(lhs_md, rhs_md, bias_md, ret_md);
+      dnnl::matmul::primitive_desc pd(md, g_comp->eng);
+      dnnl::primitive prim = dnnl::matmul(pd);
+      add_op(prim, {{DNNL_ARG_SRC, rhs_mem},
+                    {DNNL_ARG_WEIGHTS, rhs_mem},
+                    {DNNL_ARG_BIAS, bias_mem},
+                    {DNNL_ARG_DST, ret_mem}});
+    }
+    else if(bias_elements == 1) {
+      dnnl::post_ops ops;
+      dnnl::primitive_attr gemm_attr;
+      float beta = ((float *)bias->mem.get_data_handle())[0];
+      ops.append_eltwise(1.f, dnnl::algorithm::eltwise_linear, 0.f, beta);
+      gemm_attr.set_post_ops(ops);
+      dnnl::matmul::desc md(lhs_md, rhs_md, ret_md);
+      dnnl::matmul::primitive_desc pd(md, gemm_attr, g_comp->eng);
+      dnnl::primitive prim = dnnl::matmul(pd);
+      add_op(prim, {{DNNL_ARG_SRC, rhs_mem},
+                    {DNNL_ARG_WEIGHTS, rhs_mem},
+                    {DNNL_ARG_DST, ret_mem}});
+    } else 
+        is_elements_add = true;
   } else {
     dnnl::matmul::desc md(lhs_md, rhs_md, ret_md);
     dnnl::matmul::primitive_desc pd(md, g_comp->eng);
@@ -1323,13 +1342,13 @@ odla_value odla_Gemm(odla_value lhs, odla_bool transpose_lhs, odla_value rhs,
                   {DNNL_ARG_DST, ret_mem}});
   }
 
-  odla_value v = CreateValue(ret_mem, output_dims, id);
+  odla_value v = CreateValue(ret_mem, output_dims, is_elements_add ? nullptr : id);
 
   InterpretIfNeeded();
 
-  return v;
+  return is_elements_add ? odla_Add(v, bias, id) : v;
 }
-
+  
 odla_value odla_Erf(odla_value input, const odla_value_id value_id) {
   std::function<void()> op;
   const auto& input_shape = input->shape;


### PR DESCRIPTION
halo doesn't check the gemm+add op's shape, so we need to see if the add op is bias_add  or not in odla_dnnl