### PR TITLE
Fix a build error when building with some ODLA platform off

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,10 +19,6 @@ set(HALO_TEST_DEPENDS
   RTLIB
   halolib
   halo
-  #odla_tensorrt
-  #odla_dnnl
-  #odla_eigen
-  #odla_xnnpack
   analyzer
   diagnostic
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,13 +19,30 @@ set(HALO_TEST_DEPENDS
   RTLIB
   halolib
   halo
-  odla_tensorrt
-  odla_dnnl
-  odla_eigen
-  odla_xnnpack
+  #odla_tensorrt
+  #odla_dnnl
+  #odla_eigen
+  #odla_xnnpack
   analyzer
   diagnostic
 )
+
+if (ODLA_BUILD_TRT)
+  list(APPEND HALO_TEST_DEPENDS odla_tensorrt)
+endif()
+
+if (ODLA_BUILD_DNNL)
+  list(APPEND HALO_TEST_DEPENDS odla_dnnl)
+endif()
+
+if (ODLA_BUILD_EIGEN)
+  list(APPEND HALO_TEST_DEPENDS odla_eigen)
+endif()
+
+if (ODLA_BUILD_XNNPACK)
+  list(APPEND HALO_TEST_DEPENDS odla_xnnpack)
+endif()
+
 
 configure_lit_site_cfg(
     ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in


### PR DESCRIPTION
Target check-halo depends on target odla_tensorrt, odla_dnnl,odla_eigen etc, which in-turn are dependent on option ODLA_BUILD_TRT, ODLA_BUILD_DNNL,ODLA_BUILD_EIGEN respectively. 