### PR TITLE
DNNL: support layout propagation for nchw layout, better performance

### DIFF
--- a/tests/unittests/lit_cases/test_dnnl/test_averagepool_1d_default_dnnl.cc
+++ b/tests/unittests/lit_cases/test_dnnl/test_averagepool_1d_default_dnnl.cc
@@ -25,5 +25,5 @@
 // RUN: %t_dnnl.exe 0.0001 0 dnnl %data_path/test_averagepool_1d_default | FileCheck %s
 // CHECK: Result Pass
 // clang-format on
-// XFAIL: *
+
 #include "test_averagepool_1d_default_dnnl.cc.tmp.main.cc.in"


### PR DESCRIPTION
1. support layout propagation for nchw layout, refer to https://oneapi-src.github.io/oneDNN/memory_format_propagation_cpp
2. fix nhwc layout memory desc bug.
