### PR TITLE
Prevent re-entry of input type legalizer pass

### DIFF
--- a/armory/analyzer/driver.cc
+++ b/armory/analyzer/driver.cc
@@ -60,7 +60,8 @@ static void PopulatePassesAndRun(GlobalContext& ctx, Module& m,
                                  Parser::Format format) {
   PassManager pm(ctx);
   std::vector<std::string> input_shapes(InputsShape.begin(), InputsShape.end());
-  pm.AddPass<InputLegalizer>(batch.getValue(), input_shapes);
+  pm.AddPass<InputLegalizer>(batch.getValue(), input_shapes,
+                             PreprocessScale.getValue());
   if (format == Parser::Format::CAFFE) {
     pm.AddPass<CAFFEExtensionLegalizer>();
   } else if (format == Parser::Format::TENSORFLOW) {

--- a/driver/driver.cc
+++ b/driver/driver.cc
@@ -373,7 +373,8 @@ static void PopulatePasses(PassManager* pm, std::ostream* out_code,
                            bool is_c_or_cxx_output, bool is_binary_output,
                            Parser::Format format) {
   std::vector<std::string> input_shapes(InputsShape.begin(), InputsShape.end());
-  pm->AddPass<InputLegalizer>(Batch.getValue(), input_shapes);
+  pm->AddPass<InputLegalizer>(Batch.getValue(), input_shapes,
+                              PreprocessScale.getValue());
   if (!Outputs.empty()) {
     std::vector<std::string> outputs(Outputs.begin(), Outputs.end());
     pm->AddPass<OutputRewriter>(outputs);

--- a/include/halo/lib/transforms/input_legalizer.h
+++ b/include/halo/lib/transforms/input_legalizer.h
@@ -17,6 +17,7 @@
 
 #ifndef HALO_LIB_TRANSFORMS_INPUT_LEGALIZER_H_
 #define HALO_LIB_TRANSFORMS_INPUT_LEGALIZER_H_
+#include <unordered_set>
 
 #include "halo/lib/pass/pass.h"
 
@@ -38,6 +39,7 @@ class InputLegalizer final : public FunctionPass {
   int batch_size_;
   std::vector<std::string> inputs_shapes_;
   std::string scale_str_;
+  std::unordered_set<const Function*> handled_func_;
 };
 
 } // end namespace halo.

--- a/include/halo/lib/transforms/input_legalizer.h
+++ b/include/halo/lib/transforms/input_legalizer.h
@@ -25,16 +25,19 @@ namespace halo {
 /// This pass eliminates dead IRs.
 class InputLegalizer final : public FunctionPass {
  public:
-  InputLegalizer(int batch_size, const std::vector<std::string>& inputs_shapes)
+  InputLegalizer(int batch_size, const std::vector<std::string>& inputs_shapes,
+                 const std::string& scale_str)
       : FunctionPass("Legalize inputs"),
         batch_size_(batch_size),
-        inputs_shapes_(inputs_shapes) {}
+        inputs_shapes_(inputs_shapes),
+        scale_str_(scale_str) {}
 
   bool RunOnFunction(Function* func) override;
 
  private:
   int batch_size_;
   std::vector<std::string> inputs_shapes_;
+  std::string scale_str_;
 };
 
 } // end namespace halo.

--- a/include/halo/utils/cl_options.h
+++ b/include/halo/utils/cl_options.h
@@ -54,6 +54,16 @@ static llvm::cl::list<std::string> InputsShape(
     llvm::cl::desc("Specify input names like -input-shape=foo:1x3x100x100 "
                    "-input-shape=bar:int8:-1x3x200x200"));
 
+static llvm::cl::opt<std::string> PreprocessScale(
+    "preproc-scale",
+    llvm::cl::desc(
+        "Insert scale operation to input. E.g. "
+        "`-preproc-scale:1.0,-2.0,3.0,10,20,30`."
+        "The number of values are comma separated and should be "
+        "even. The first n values are for addition, the next n "
+        "values are for multiplication. It should be broadcasting "
+        "to input shape. Invalid if there are more than one inputs. "));
+
 /// Guess the model format based on input file extension.gg
 static Parser::Format InferFormat(
     const llvm::cl::list<std::string>& model_files, size_t file_idx) {

--- a/lib/transforms/input_legalizer.cc
+++ b/lib/transforms/input_legalizer.cc
@@ -17,6 +17,11 @@
 
 #include "halo/lib/transforms/input_legalizer.h"
 
+#include <functional>
+#include <numeric>
+
+#include "halo/lib/ir/ir_builder.h"
+
 namespace halo {
 
 static std::unordered_map<std::string, halo::Type> ParseInputShapes(
@@ -79,6 +84,20 @@ static std::unordered_map<std::string, halo::Type> ParseInputShapes(
   return results;
 }
 
+static std::vector<float> ParsePreprocessScale(const std::string& str) {
+  std::istringstream iss(str);
+  std::vector<float> values;
+  constexpr int n = 6;
+  values.reserve(n);
+  float v;
+  char comma;
+  while (iss >> v && values.size() < n) {
+    values.push_back(v);
+    iss >> comma;
+  }
+  return values;
+}
+
 bool InputLegalizer::RunOnFunction(Function* func) {
   bool changed = false;
   auto specified_shapes = ParseInputShapes(
@@ -112,6 +131,68 @@ bool InputLegalizer::RunOnFunction(Function* func) {
 
   HLCHECK(specified_shapes.empty() && "Unclaimed specified shapes");
 
+  if (!scale_str_.empty()) {
+    constexpr int n = 6;
+    auto v = ParsePreprocessScale(scale_str_);
+    if (func->Args().size() != 1) {
+      std::cerr << "Preprocess only works for model with exactly one input. "
+                   "Ignore preprocessing.\n";
+    } else if (v.size() != n) {
+      std::cerr << "Invalid number of scale parameters (" << v.size()
+                << " != " << n << ") Ignore preprocessing.\n";
+    } else {
+      // Insert scale.
+      auto arg = func->Args().begin()->get();
+      std::vector<float> bias(v.begin(), v.begin() + n / 2);
+      std::vector<float> scale(v.begin() + n / 2, v.end());
+      ConstantBuilder cb(func->GetParent());
+      std::vector<int64_t> shape{n / 2};
+      const auto& arg_type = arg->GetResultType();
+      for (int64_t i = arg_type.GetNumOfDims() - 1; i >= 0; --i) {
+        if (arg_type.GetNumOfElementsInDim(i) != n / 2) {
+          shape.push_back(1);
+        }
+      }
+      // prepand ones.
+      for (int64_t i = 0, e = arg_type.GetNumOfDims() - shape.size(); i < e;
+           ++i) {
+        shape.insert(shape.begin(), 1);
+      }
+      if (std::accumulate(shape.begin(), shape.end(), 1,
+                          std::multiplies<int64_t>()) != n / 2) {
+        std::cerr << "Preprocess element number does not match with input "
+                     "type. Ignore preprocessing.\n";
+        scale_str_.clear();
+        return changed;
+      }
+
+      halo::Type dt{DataType::FLOAT32, shape};
+      BasicBlock* bb = func->begin()->get();
+      IRBuilder builder(bb);
+      if (!bb->empty()) {
+        builder.SetInsertBefore(bb->begin()->get());
+      }
+      Def input = *arg;
+      auto addend = cb.CreateConstant("_pp_addend", dt, bias.data());
+      if (!addend->HasSameValueOf(0)) {
+        Def new_def = *builder.CreateAdd("pp_add", input, *addend);
+        input.GetOwner()->ReplaceAllUsesWith(0, new_def);
+        input = new_def;
+        changed = true;
+      }
+      auto coeff = cb.CreateConstant("_pp_scale", dt, scale.data());
+      if (!coeff->HasSameValueOf(1)) {
+        Def new_def = *builder.CreateMul("_pp_scale", input, *coeff);
+        input.GetOwner()->ReplaceAllUsesWith(0, new_def);
+        changed = true;
+      }
+    }
+    std::cout << v.size() << std::endl;
+    for (auto x : v) {
+      std::cout << x << "\n";
+    }
+    scale_str_.clear(); // Prevent re-entry.
+  }
   return changed;
 }
 

--- a/lib/transforms/input_legalizer.cc
+++ b/lib/transforms/input_legalizer.cc
@@ -145,7 +145,7 @@ bool InputLegalizer::RunOnFunction(Function* func) {
       auto arg = func->Args().begin()->get();
       std::vector<float> bias(v.begin(), v.begin() + n / 2);
       std::vector<float> scale(v.begin() + n / 2, v.end());
-      ConstantBuilder cb(func->GetParent());
+      ConstantBuilder cb(func);
       std::vector<int64_t> shape{n / 2};
       const auto& arg_type = arg->GetResultType();
       for (int64_t i = arg_type.GetNumOfDims() - 1; i >= 0; --i) {

--- a/lib/transforms/input_legalizer.cc
+++ b/lib/transforms/input_legalizer.cc
@@ -100,6 +100,9 @@ static std::vector<float> ParsePreprocessScale(const std::string& str) {
 
 bool InputLegalizer::RunOnFunction(Function* func) {
   bool changed = false;
+  if (handled_func_.count(func) != 0) {
+    return false;
+  }
   auto specified_shapes = ParseInputShapes(
       inputs_shapes_,
       (func->Args().size() == 1) ? (*func->Args().begin())->GetName() : "");
@@ -193,6 +196,7 @@ bool InputLegalizer::RunOnFunction(Function* func) {
     }
     scale_str_.clear(); // Prevent re-entry.
   }
+  handled_func_.insert(func);
   return changed;
 }
 


### PR DESCRIPTION
This pass is supposed to be run once.
When the input shape is overridden for batching size, the input shape is fixed.
Subsequent passes may further update the input shape for some optimizations. Rerun Input Shape Legalizer will cause side-effects.

This patch solves #198 