### PR TITLE
Support the print of vcs info in "--version" output

### DIFF
--- a/cmake/modules/zbuild_llvm.cmake
+++ b/cmake/modules/zbuild_llvm.cmake
@@ -26,7 +26,7 @@ add_subdirectory(${LLVM_SRC_DIR} ${CMAKE_BINARY_DIR}/llvm EXCLUDE_FROM_ALL)
 set(CMAKE_MODULE_PATH ${LLVM_SRC_DIR}/cmake/modules)
 include(DetermineGCCCompatible)
 
-function(halo_tblgen ofn) 
+function(halo_tblgen ofn)
   tablegen(HALO ${ARGV} "-I${CMAKE_SOURCE_DIR}/include/halo/lib/ir")
   set(TABLEGEN_OUTPUT ${TABLEGEN_OUTPUT}
     ${CMAKE_CURRENT_BINARY_DIR}/${ofn} PARENT_SCOPE

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -17,3 +17,4 @@
 add_executable(halo driver.cc)
 
 target_link_libraries(halo halolib)
+add_dependencies(halo halo_version_h)

--- a/driver/driver.cc
+++ b/driver/driver.cc
@@ -448,6 +448,12 @@ static bool FormatCode(const std::string& filename) {
 static void PrintVersion(llvm::raw_ostream& os) {
   os << "  Version:\t" << HALO_MAJOR << '.' << HALO_MINOR << '.' << HALO_PATCH
      << '\n';
+#ifdef HALO_REVISION
+  os << "  HALO Repo:" << HALO_REPOSITORY << " Rev:" << HALO_REVISION << '\n';
+#endif
+#ifdef ODLA_REVISION
+  os << "  ODLA Repo:" << ODLA_REPOSITORY << " Rev:" << ODLA_REVISION << '\n';
+#endif
 #ifndef NDEBUG
   os << "  Build:\tDebug\n";
 #else

--- a/include/halo/CMakeLists.txt
+++ b/include/halo/CMakeLists.txt
@@ -15,3 +15,31 @@
 # ==============================================================================
 
 add_subdirectory(lib)
+
+# Generate VCS info.
+set(version_inc "${CMAKE_CURRENT_BINARY_DIR}/version.inc")
+
+find_first_existing_vc_file("${CMAKE_SOURCE_DIR}" halo_vc)
+
+if (halo_vc)
+  set(LLVM_SRC_DIR ${CMAKE_SOURCE_DIR}/external/llvm-project/llvm)
+  set(LLVM_CMAKE_PATH ${LLVM_SRC_DIR}/cmake/modules)
+  set(get_version_script "${LLVM_CMAKE_PATH}/GenerateVersionFromVCS.cmake")
+
+  add_custom_command(OUTPUT "${version_inc}"
+    DEPENDS "${halo_vc}" "${get_version_script}"
+    COMMAND
+    ${CMAKE_COMMAND} "-DHALO_SOURCE_DIR=${CMAKE_SOURCE_DIR}"
+                     "-DODLA_SOURCE_DIR=${CMAKE_SOURCE_DIR}/ODLA"
+                     "-DNAMES=\"HALO;ODLA\""
+                     "-DHEADER_FILE=${version_inc}"
+                     -P "${get_version_script}")
+  set_source_files_properties("${version_inc}"
+    PROPERTIES GENERATED TRUE
+    HEADER_FILE_ONLY TRUE)
+else()
+  message(WARNING "revision info unavailable")
+  file(WRITE "${version_inc}" "")
+endif()
+
+add_custom_target(halo_version_h DEPENDS "${version_inc}")

--- a/include/halo/version.h
+++ b/include/halo/version.h
@@ -25,4 +25,6 @@
 //! \brief HALO version number.
 #define HALO_VERSION_NUMBER ((HALO_MAJOR)*100 + (HALO_MINOR)*10 + (OLDA_PATCH))
 
+#include "halo/version.inc"
+
 #endif // HALO_VERSION_H_

--- a/tests/driver/test_driver.cc
+++ b/tests/driver/test_driver.cc
@@ -20,3 +20,4 @@
 // RUN: %halo_compiler -version 2>&1 | FileCheck %s
 
 // CHECK: Version:	0.6.0
+// CHECK: HALO Repo:{{.*}} Rev:


### PR DESCRIPTION
Now, halo --version will output: HALO_VERSION, HALO REPO/REV and Build Type.