### PR TITLE
[TypeLegalizer] Check dims of shape in for conv & pooling

### DIFF
--- a/lib/transforms/type_legalizer.cc
+++ b/lib/transforms/type_legalizer.cc
@@ -324,6 +324,7 @@ static Type ComputeKernelWiseType(
       ImageAxisInfo::GetImageAxisInfo(data_format, kernel_format);
   auto& data_shape = data_type.GetDimSizes();
   auto ret_shape = data_shape;
+  HLCHECK(data_type.GetNumOfDims() == 4);
 
   int kernel_h = kernel_shape[info.kernel_height_axis];
   int kernel_w = kernel_shape[info.kernel_width_axis];

--- a/tests/unittests/lit_cases/test_popart/test_averagepool_1d_default_popart.cc
+++ b/tests/unittests/lit_cases/test_popart/test_averagepool_1d_default_popart.cc
@@ -25,4 +25,5 @@
 // RUN: %t_popart.exe 0.0001 0 popart %data_path/test_averagepool_1d_default | FileCheck %s
 // CHECK: Result Pass
 // clang-format on
-#include "test_averagepool_1d_default_popart.cc.tmp.main.cc.in"
+// XFAIL: *
+#include "test_averagepool_1d_default_popart.cc.tmp.main.cc.in" q

--- a/tests/unittests/lit_cases/test_popart/test_averagepool_1d_default_popart.cc
+++ b/tests/unittests/lit_cases/test_popart/test_averagepool_1d_default_popart.cc
@@ -26,4 +26,4 @@
 // CHECK: Result Pass
 // clang-format on
 // XFAIL: *
-#include "test_averagepool_1d_default_popart.cc.tmp.main.cc.in" q
+#include "test_averagepool_1d_default_popart.cc.tmp.main.cc.in"

--- a/tests/unittests/lit_cases/test_popart/test_convtranspose_1d_popart.cc
+++ b/tests/unittests/lit_cases/test_popart/test_convtranspose_1d_popart.cc
@@ -26,4 +26,5 @@
 // RUN: %t_popart.exe 0.0001 0 popart %data_path/test_convtranspose_1d | FileCheck %s
 // CHECK: Result Pass
 // clang-format on
+// XFAIL: *
 #include "test_convtranspose_1d_popart.cc.tmp.main.cc.in"

--- a/tests/unittests/lit_cases/test_popart/test_maxpool_1d_default_popart.cc
+++ b/tests/unittests/lit_cases/test_popart/test_maxpool_1d_default_popart.cc
@@ -25,4 +25,5 @@
 // RUN: %t_popart.exe 0.0001 0 popart %data_path/test_maxpool_1d_default | FileCheck %s
 // CHECK: Result Pass
 // clang-format on
+// XFAIL: *
 #include "test_maxpool_1d_default_popart.cc.tmp.main.cc.in"


### PR DESCRIPTION
Currently, the conv & pooling only computes output shape for 4D tensors.
If input is 3D, out-of-bound access will occur.