### PR TITLE
[Utils] Support DynCast/IsA with subclasses of Instruction

### DIFF
--- a/include/halo/lib/framework/common.h
+++ b/include/halo/lib/framework/common.h
@@ -54,6 +54,11 @@ T_NEW* Downcast(T_OLD* ptr) {
   return static_cast<T_NEW*>(ptr);
 }
 
+template <typename T_NEW, typename T_OLD>
+const T_NEW* Downcast(const T_OLD* ptr) {
+  return static_cast<const T_NEW*>(ptr);
+}
+
 template <typename T_TO, typename T_FROM>
 bool IsA(const T_FROM* obj) {
   return T_TO::Classof(obj);
@@ -66,6 +71,11 @@ T_TO* DynCast(T_FROM* ptr) {
     return nullptr;
   }
   return Downcast<T_TO>(ptr);
+}
+
+template <typename T_TO, typename T_FROM>
+const T_TO* DynCast(const T_FROM* ptr) {
+  return DynCast<T_TO>(const_cast<T_FROM*>(ptr));
 }
 
 } // namespace halo

--- a/include/halo/lib/ir/instruction.h
+++ b/include/halo/lib/ir/instruction.h
@@ -92,6 +92,11 @@ T_TO* DynCast(Instruction* inst) {
   return Downcast<T_TO>(inst);
 }
 
+template <typename T_TO, typename T_FROM>
+const T_TO* DynCast(const Instruction* inst) {
+  return DynCast<T_TO, T_FROM>(const_cast<Instruction*>(inst));
+}
+
 } // namespace halo
 
 #endif // HALO_LIB_IR_INSTRUCTION_H_

--- a/lib/transforms/onnxextension_legalizer.cc
+++ b/lib/transforms/onnxextension_legalizer.cc
@@ -390,11 +390,6 @@ static std::vector<Def> ConvertSlice(const ONNXExtensionInst* ext,
   if (!IsA<Constant>(op_starts) || !IsA<Constant>(op_ends)) {
     auto op_len =
         builder->CreateSub(ext->GetName() + "_len", op_ends, op_starts);
-    /*
-   int len = 1;
-   auto op_len = cb.CreateConstant(ext->GetName() + "_len",
-                                   Type{DataType::INT64, {1}}, &len);
-                                   */
     std::vector<Def> ops{op0, op_starts, *op_len};
 
     if (ext->GetNumOfOperands() >= 4) {

--- a/utils/tablegen/inst.cc
+++ b/utils/tablegen/inst.cc
@@ -406,6 +406,7 @@ void Inst::Run() {
   EmitClone();
   EmitAccessAttributes();
   EmitVerify();
+  EmitClassof();
 
   os_ << "\n";
   os_ << " private:\n";
@@ -481,6 +482,16 @@ void Inst::EmitVerify() {
   // call custom verification code.
   os_ << "    broken |= CustomVerify();\n";
   os_ << "    return broken;\n";
+  os_ << "  }\n";
+}
+
+void Inst::EmitClassof() {
+  os_ << "  static inline bool Classof(const IRObject* obj) {\n";
+  os_ << "    if (!Instruction::Classof(obj)) {\n";
+  os_ << "      return false;\n";
+  os_ << "    }\n";
+  os_ << "    const Instruction* inst = DynCast<Instruction>(obj);\n";
+  os_ << "    return inst->GetOpCode() == " << opcode_ << ";\n";
   os_ << "  }\n";
 }
 

--- a/utils/tablegen/inst.h
+++ b/utils/tablegen/inst.h
@@ -157,7 +157,9 @@ class Inst {
   void EmitInitAttributes();
   /// Emit a public function to copy attributes from the same Instr class.
   void EmitVerify();
-  /// Emit formated (markdown) document
+  /// Emit classof and casting code.
+  void EmitClassof();
+  /// Emit formated (markdown) document.
   void EmitDoc();
 
  private:


### PR DESCRIPTION
Originally, to check if an IRObject* is a specific instruction, it needs
to be written like:
`IsA<Instruction>(obj) && DynCast<Instruction>(obj)->GetOpCOde() == OpCode::XYZ`

This patch simplifies it to `IsA<XYZInstr>(obj)`