### PR TITLE
enable cache & add detach when destroy computation

### DIFF
--- a/ODLA/platforms/odla_popart/CMakeLists.txt
+++ b/ODLA/platforms/odla_popart/CMakeLists.txt
@@ -34,7 +34,7 @@ set(POPART_ROOT ${POPART_ROOT} PARENT_SCOPE)
 
 list(APPEND CMAKE_PREFIX_PATH ${POPLAR_ROOT})
 list(APPEND CMAKE_PREFIX_PATH ${POPART_ROOT})
-find_package(popart 2.1.0... REQUIRED CONFIG COMPONENTS popart-only REQUIRED)
+find_package(popart 2.2.0... REQUIRED CONFIG COMPONENTS popart-only REQUIRED)
 
 message(STATUS "Found popart, version: ${popart_VERSION}")
 

--- a/ODLA/platforms/odla_popart/CMakeLists.txt
+++ b/ODLA/platforms/odla_popart/CMakeLists.txt
@@ -34,7 +34,7 @@ set(POPART_ROOT ${POPART_ROOT} PARENT_SCOPE)
 
 list(APPEND CMAKE_PREFIX_PATH ${POPLAR_ROOT})
 list(APPEND CMAKE_PREFIX_PATH ${POPART_ROOT})
-find_package(popart 2.2.0... REQUIRED CONFIG COMPONENTS popart-only REQUIRED)
+find_package(popart 2.1.0... REQUIRED CONFIG COMPONENTS popart-only REQUIRED)
 
 message(STATUS "Found popart, version: ${popart_VERSION}")
 

--- a/ODLA/platforms/odla_popart/custom_ops/erf.cc
+++ b/ODLA/platforms/odla_popart/custom_ops/erf.cc
@@ -74,7 +74,7 @@ public:
 
   void grow(poplar::program::Sequence& prog) const final {
 
-    Tensor x = getInTensor(0);
+    Tensor x = getInTensor(0).getPoplarTensor();
 
     Tensor sign = popops::signum(graph().getPoplarGraph(), x, prog);
     Tensor y = popops::abs(graph().getPoplarGraph(), x, prog);
@@ -99,7 +99,7 @@ public:
     popops::addInPlace(graph().getPoplarGraph(), y, 1.0f, prog);
     popops::mulInPlace(graph().getPoplarGraph(), y, sign, prog);
 
-    setOutTensor(0, y);
+    setOutTensor(0, snap::Tensor{y, graph()});
   }
 };
 

--- a/ODLA/platforms/odla_popart/custom_ops/rsqrt.cc
+++ b/ODLA/platforms/odla_popart/custom_ops/rsqrt.cc
@@ -65,8 +65,10 @@ RsqrtOpx::RsqrtOpx(popart::Op * op, popart::popx::Devicex * devicex)
 }
 
 void RsqrtOpx::grow(poplar::program::Sequence & prog) const {
-  setOutTensor(0, popops::map(graph().getPoplarGraph(), popops::expr::UnaryOpType::RSQRT,
-                              getInTensor(0), prog, debugContext()));
+  auto result = popops::map(graph().getPoplarGraph(),
+		                    popops::expr::UnaryOpType::RSQRT,
+			                getInTensor(0).getPoplarTensor(), prog, debugContext());
+  setOutTensor(0, snap::Tensor{result, graph()});
 }
 
 namespace {

--- a/ODLA/platforms/odla_popart/odla_compute.cc
+++ b/ODLA/platforms/odla_popart/odla_compute.cc
@@ -168,7 +168,7 @@ odla_status odla_CreateContext(odla_context* context) {
   auto proto = g_comp->builder->getModelProto();
   auto session = popart::InferenceSession::createFromOnnxModel(
       proto, data_flow, device, popart::InputShapeInfo(), *opts);
-  *context = new odla_context(g_comp, std::move(session));
+  *context = new _odla_context(std::move(session));
   g_comp->context = *context;
 
   // Compile graph, create engine and load into the IPU

--- a/ODLA/platforms/odla_popart/odla_compute.cc
+++ b/ODLA/platforms/odla_popart/odla_compute.cc
@@ -77,8 +77,8 @@ std::unique_ptr<popart::SessionOptions> SessionOptions() {
   const char* envEngineCachePath = getenv("ENGINE_CACHE_PATH");
   if (g_comp->opts.enable_engine_cache || envEngineCachePath != nullptr) {
     opts->enableEngineCaching = true;
-    opts->cachePath = g_comp->opts.enable_engine_cache ? 
-	              g_comp->opts.cache_dir : envEngineCachePath;
+    opts->cachePath = g_comp->opts.enable_engine_cache ? g_comp->opts.cache_dir
+	                                               : envEngineCachePath;
   }
   return opts;
 }
@@ -110,7 +110,7 @@ odla_status odla_SetComputationItem(odla_computation comp, odla_item_type type,
 }
 
 odla_status odla_StoreExecutable(const odla_char* file_name,
-    odla_executable executable) {
+                                 odla_executable executable) {
   return ODLA_SUCCESS;
 }
 
@@ -143,7 +143,7 @@ odla_status odla_CreateComputation(odla_computation* comp) {
     }
   }
 
-    // Create dataflow
+  // Create dataflow
   std::vector<popart::TensorId> ids;
   for (const auto& output : g_comp->outputs_map) {
     ids.push_back(output.second->tensor_id);

--- a/ODLA/platforms/odla_popart/odla_compute.cc
+++ b/ODLA/platforms/odla_popart/odla_compute.cc
@@ -78,7 +78,7 @@ std::unique_ptr<popart::SessionOptions> SessionOptions() {
   if (g_comp->opts.enable_engine_cache || envEngineCachePath != nullptr) {
     opts->enableEngineCaching = true;
     opts->cachePath = g_comp->opts.enable_engine_cache ? g_comp->opts.cache_dir
-	                                                : envEngineCachePath;
+                                                       : envEngineCachePath;
   }
   return opts;
 }

--- a/ODLA/platforms/odla_popart/odla_compute.cc
+++ b/ODLA/platforms/odla_popart/odla_compute.cc
@@ -78,7 +78,7 @@ std::unique_ptr<popart::SessionOptions> SessionOptions() {
   if (g_comp->opts.enable_engine_cache || envEngineCachePath != nullptr) {
     opts->enableEngineCaching = true;
     opts->cachePath = g_comp->opts.enable_engine_cache ? g_comp->opts.cache_dir
-	                                               : envEngineCachePath;
+	                                                : envEngineCachePath;
   }
   return opts;
 }

--- a/ODLA/platforms/odla_popart/odla_compute.cc
+++ b/ODLA/platforms/odla_popart/odla_compute.cc
@@ -147,7 +147,7 @@ odla_status odla_CreateComputation(odla_computation* comp) {
 
 odla_status odla_CreateContext(odla_context* context) {
   *context = new _odla_context(g_comp);
-    // Create dataflow
+  // Create dataflow
   std::vector<popart::TensorId> ids;
   for (const auto& output : g_comp->outputs_map) {
     ids.push_back(output.second->tensor_id);
@@ -183,7 +183,7 @@ odla_status odla_CreateContext(odla_context* context) {
 
 odla_status odla_DestroyContext(odla_context ctx) {
   if (ctx != nullptr) {
-      delete (ctx);
+    delete (ctx);
   }
   return ODLA_SUCCESS;
 }
@@ -193,9 +193,11 @@ odla_status odla_DestroyComputation(odla_computation comp) {
     comp->session->getDevice().getDeviceInfo()->detach();
     comp->session.reset();
   }
-  if (g_comp = nullptr) {
-    delete g_comp;
+
+  if (g_comp == comp && g_comp != nullptr) {
+    g_comp = nullptr;
   }
+
   return ODLA_SUCCESS;
 }
 
@@ -272,8 +274,7 @@ odla_status odla_BindToArgumentById(const odla_value_id value_id,
                                     const odla_void* data_ptr,
                                     odla_context context) {
   std::string name(reinterpret_cast<const char*>(value_id));
-  return odla_BindToArgument(g_comp->inputs_map[name], data_ptr,
-                             context);
+  return odla_BindToArgument(g_comp->inputs_map[name], data_ptr, context);
 }
 
 odla_status odla_SetValueAsOutput(const odla_value value) {

--- a/ODLA/platforms/odla_popart/odla_compute.cc
+++ b/ODLA/platforms/odla_popart/odla_compute.cc
@@ -32,6 +32,7 @@
 #include <popart/devicemanager.hpp>
 #include <popart/names.hpp>
 #include <popart/ndarraywrapper.hpp>
+#include <popart/popx/devicex.hpp>
 #include <popart/session.hpp>
 #include <popart/sessionoptions.hpp>
 #include <popart/stepio.hpp>
@@ -51,6 +52,7 @@
 #endif
 
 thread_local odla_computation g_comp;
+thread_local volatile bool comp_initialized = false;
 static std::vector<std::unique_ptr<_odla_computation>> g_comps;
 
 static std::shared_ptr<popart::DeviceInfo> AcquireAvailableDevice(
@@ -72,6 +74,12 @@ std::unique_ptr<popart::SessionOptions> SessionOptions() {
       std::unique_ptr<popart::SessionOptions>(new popart::SessionOptions());
   opts->virtualGraphMode = popart::VirtualGraphMode::Auto;
   opts->enableStochasticRounding = true;
+  const char* envEngineCachePath = getenv("ENGINE_CACHE_PATH");
+  if (g_comp->opts.enable_engine_cache || envEngineCachePath != nullptr) {
+    opts->enableEngineCaching = true;
+    opts->cachePath = g_comp->opts.enable_engine_cache ? 
+	              g_comp->opts.cache_dir : envEngineCachePath;
+  }
   return opts;
 }
 
@@ -91,13 +99,25 @@ odla_status odla_SetComputationItem(odla_computation comp, odla_item_type type,
       comp->opts.enable_engine_cache = *(reinterpret_cast<bool*>(value));
       break;
     case ODLA_CACHE_DIR:
-      comp->opts.cache_dir = *(reinterpret_cast<char**>(value));
+      comp->opts.cache_dir = (reinterpret_cast<char*>(value));
       break;
     default:
       std::cerr << "Unsupported property type: " << type << std::endl;
       return ODLA_FAILURE;
   }
 
+  return ODLA_SUCCESS;
+}
+
+odla_status odla_StoreExecutable(const odla_char* file_name,
+    odla_executable executable) {
+  return ODLA_SUCCESS;
+}
+
+odla_status odla_LoadExecutable(const odla_char* file_name,
+                                odla_executable* executable,
+                                odla_context* context,
+                                odla_computation* computation) {
   return ODLA_SUCCESS;
 }
 
@@ -123,41 +143,17 @@ odla_status odla_CreateComputation(odla_computation* comp) {
     }
   }
 
-  return ODLA_SUCCESS;
-}
-
-odla_status odla_CreateContext(odla_context* context) {
-  // Create dataflow
+    // Create dataflow
   std::vector<popart::TensorId> ids;
   for (const auto& output : g_comp->outputs_map) {
     ids.push_back(output.second->tensor_id);
   }
 
-  // Batches per step is a compile time constant value
-  popart::DataFlow data_flow(g_comp->opts.batches_per_step, ids,
-                             popart::AnchorReturnType("All"));
+  return ODLA_SUCCESS;
+}
 
-  // Acquire IPU
-  auto device = g_comp->opts.use_ipu_model
-                    ? CreateIpuModelDevice(g_comp->opts.ipu_num)
-                    : AcquireAvailableDevice(g_comp->opts.ipu_num);
-
-  // Create and config SessionOptions
-  auto opts = SessionOptions();
-
-  // Create InferenceSession
-  auto proto = g_comp->builder->getModelProto();
-  auto session = popart::InferenceSession::createFromOnnxModel(
-      proto, data_flow, device, popart::InputShapeInfo(), *opts);
-  *context = new _odla_context(g_comp, std::move(session));
-
-  // Compile graph, create engine and load into the IPU
-  // use compileAndExport() to frozen engine to specified path
-  (*context)->session->prepareDevice();
-  // Init seed
-  (*context)->session->setRandomSeed(0);
-  // Copy weights from host to IPU
-  (*context)->session->weightsFromHost();
+odla_status odla_CreateContext(odla_context* context) {
+  *context = new _odla_context(g_comp);
 
   return ODLA_SUCCESS;
 }
@@ -168,6 +164,11 @@ odla_status odla_DestroyContext(odla_context ctx) {
 }
 
 odla_status odla_DestroyComputation(odla_computation comp) {
+  comp_initialized = false;
+  if (comp->session != nullptr) {
+    comp->session->getDevice().getDeviceInfo()->detach();
+    comp->session.reset();
+  }
   // g_comp.reset();
   return ODLA_SUCCESS;
 }
@@ -175,19 +176,53 @@ odla_status odla_DestroyComputation(odla_computation comp) {
 odla_status odla_ExecuteComputation(odla_computation comp, odla_context context,
                                     odla_compute_mode mode,
                                     odla_device device) {
+  if (!comp_initialized) {
+    // Create dataflow
+    std::vector<popart::TensorId> ids;
+    for (const auto& output : g_comp->outputs_map) {
+      ids.push_back(output.second->tensor_id);
+    }
+
+    // Batches per step is a compile time constant value
+    popart::DataFlow data_flow(g_comp->opts.batches_per_step, ids,
+                               popart::AnchorReturnType("All"));
+
+    // Acquire IPU
+    auto device = g_comp->opts.use_ipu_model
+                      ? CreateIpuModelDevice(g_comp->opts.ipu_num)
+                      : AcquireAvailableDevice(g_comp->opts.ipu_num);
+
+    // Create and config SessionOptions
+    auto opts = SessionOptions();
+
+    // Create InferenceSession
+    auto proto = g_comp->builder->getModelProto();
+    g_comp->session = popart::InferenceSession::createFromOnnxModel(
+        proto, data_flow, device, popart::InputShapeInfo(), *opts);
+
+    // Compile graph, create engine and load into the IPU
+    // use compileAndExport() to frozen engine to specified path
+    g_comp->session->prepareDevice();
+    // Init seed
+    g_comp->session->setRandomSeed(0);
+    // Copy weights from host to IPU
+    g_comp->session->weightsFromHost();
+
+    comp_initialized = true;
+  }
   // Config StepIO
   std::map<popart::TensorId, popart::IArray&> inputs;
-  for (auto& input : comp->inputs) {
+  for (auto& input : context->inputs) {
     inputs.emplace(input.first, *input.second);
   }
   std::map<popart::TensorId, popart::IArray&> outputs;
-  for (auto& output : comp->outputs) {
+  for (auto& output : context->outputs) {
     outputs.emplace(output.first, *output.second);
   }
 
   popart::StepIO stepio(inputs, outputs);
   // Run on ipu
-  context->session->run(stepio);
+  g_comp->session->run(stepio);
   return ODLA_SUCCESS;
 }
 
@@ -237,7 +272,7 @@ odla_status odla_BindToArgument(odla_value value, const odla_void* data_ptr,
   std::unique_ptr<popart::IArray> p_array = MakeNDArrayWrapper(
       data_ptr, context->comp->builder->getTensorDataType(value->tensor_id),
       context->comp->builder->getTensorShape(value->tensor_id));
-  context->comp->inputs[value->tensor_id] = std::move(p_array);
+  context->inputs[value->tensor_id] = std::move(p_array);
   return ODLA_SUCCESS;
 }
 
@@ -285,7 +320,7 @@ odla_status odla_BindToOutput(odla_value value, odla_void* data_ptr,
   std::unique_ptr<popart::IArray> p_array = MakeNDArrayWrapper(
       data_ptr, context->comp->builder->getTensorDataType(value->tensor_id),
       context->comp->builder->getTensorShape(value->tensor_id));
-  context->comp->outputs[value->tensor_id] = std::move(p_array);
+  context->outputs[value->tensor_id] = std::move(p_array);
   return ODLA_SUCCESS;
 }
 

--- a/ODLA/platforms/odla_popart/odla_popart.h
+++ b/ODLA/platforms/odla_popart/odla_popart.h
@@ -64,8 +64,7 @@ struct _odla_value {
 
 struct _odla_computation {
   std::unique_ptr<popart::Builder> builder;
-  std::map<popart::TensorId, std::unique_ptr<popart::IArray>> inputs;
-  std::map<popart::TensorId, std::unique_ptr<popart::IArray>> outputs;
+  std::unique_ptr<popart::InferenceSession> session;
   std::unordered_map<std::string, odla_value> inputs_map;
   std::unordered_map<std::string, odla_value> outputs_map;
   std::vector<odla_value> input_values;
@@ -78,11 +77,10 @@ struct _odla_computation {
 
 struct _odla_context {
   odla_computation comp;
-  std::unique_ptr<popart::InferenceSession> session;
+  std::map<popart::TensorId, std::unique_ptr<popart::IArray>> inputs;
+  std::map<popart::TensorId, std::unique_ptr<popart::IArray>> outputs;
 
-  _odla_context(odla_computation c,
-                std::unique_ptr<popart::InferenceSession> sess)
-      : comp(c), session(std::move(sess)) {}
+  _odla_context(odla_computation c): comp(c) {}
 };
 
 #endif

--- a/ODLA/platforms/odla_popart/odla_popart.h
+++ b/ODLA/platforms/odla_popart/odla_popart.h
@@ -80,7 +80,7 @@ struct _odla_context {
   std::map<popart::TensorId, std::unique_ptr<popart::IArray>> inputs;
   std::map<popart::TensorId, std::unique_ptr<popart::IArray>> outputs;
 
-  _odla_context(odla_computation c): comp(c) {}
+  _odla_context(odla_computation c) : comp(c) {}
 };
 
 #endif

--- a/ODLA/platforms/odla_popart/odla_popart.h
+++ b/ODLA/platforms/odla_popart/odla_popart.h
@@ -76,13 +76,12 @@ struct _odla_computation {
 };
 
 struct _odla_context {
-  odla_computation comp;
   std::unique_ptr<popart::InferenceSession> session;
   std::map<popart::TensorId, std::unique_ptr<popart::IArray>> inputs;
   std::map<popart::TensorId, std::unique_ptr<popart::IArray>> outputs;
 
-  _odla_context(odla_comptation c, std::unique_ptr<popart::InferenceSession> sess)
-     : comp(c), session(std::move(sess)) {}
+  _odla_context(std::unique_ptr<popart::InferenceSession> sess)
+     : session(std::move(sess)) {}
 };
 
 #endif

--- a/ODLA/platforms/odla_popart/odla_popart.h
+++ b/ODLA/platforms/odla_popart/odla_popart.h
@@ -64,12 +64,11 @@ struct _odla_value {
 
 struct _odla_computation {
   std::unique_ptr<popart::Builder> builder;
-  std::map<popart::TensorId, std::unique_ptr<popart::IArray>> inputs;
-  std::map<popart::TensorId, std::unique_ptr<popart::IArray>> outputs;
   std::unordered_map<std::string, odla_value> inputs_map;
   std::unordered_map<std::string, odla_value> outputs_map;
   std::vector<odla_value> input_values;
   std::vector<odla_value> output_values;
+  _odla_context* context;
   target_opts opts;
 
   _odla_computation(std::unique_ptr<popart::Builder> b)
@@ -79,10 +78,11 @@ struct _odla_computation {
 struct _odla_context {
   odla_computation comp;
   std::unique_ptr<popart::InferenceSession> session;
+  std::map<popart::TensorId, std::unique_ptr<popart::IArray>> inputs;
+  std::map<popart::TensorId, std::unique_ptr<popart::IArray>> outputs;
 
-  _odla_context(odla_computation c,
-                std::unique_ptr<popart::InferenceSession> sess)
-      : comp(c), session(std::move(sess)) {}
+  _odla_context(odla_comptation c, std::unique_ptr<popart::InferenceSession> sess)
+     : comp(c), session(std::move(sess)) {}
 };
 
 #endif

--- a/utils/docker/start_docker_cpu.sh
+++ b/utils/docker/start_docker_cpu.sh
@@ -25,7 +25,7 @@ GROUPID=`id -g`
 OLD_ID=`docker ps -aq -f name=$CONTAINER_NAME -f status=running`
 
 if [ -z "$OLD_ID" ]; then
-  ID=`docker run $docker_run_flag --privileged --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -t -d --name $CONTAINER_NAME -v $MOUNT_DIR:/host -v /home:/home -v /data:/data --tmpfs /tmp:exec --rm $IMAGE `
+  ID=`docker run $docker_run_flag --privileged --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -t -d --name $CONTAINER_NAME -v $MOUNT_DIR:/host --tmpfs /tmp:exec --rm $IMAGE `
   docker exec --user root $ID groupadd -f -g $GROUPID $GROUP
   docker exec --user root $ID adduser --shell /bin/bash --uid $UID --gecos '' --ingroup $GROUP --disabled-password --home /home/$USER $USER
   docker exec --user root $ID bash -c "echo $USER ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USER && chmod 0440 /etc/sudoers.d/$USER"

--- a/utils/docker/start_docker_cpu.sh
+++ b/utils/docker/start_docker_cpu.sh
@@ -25,7 +25,7 @@ GROUPID=`id -g`
 OLD_ID=`docker ps -aq -f name=$CONTAINER_NAME -f status=running`
 
 if [ -z "$OLD_ID" ]; then
-  ID=`docker run $docker_run_flag --privileged --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -t -d --name $CONTAINER_NAME -v $MOUNT_DIR:/host  --tmpfs /tmp:exec --rm $IMAGE `
+  ID=`docker run $docker_run_flag --privileged --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -t -d --name $CONTAINER_NAME -v $MOUNT_DIR:/host -v /home:/home -v /data:/data --tmpfs /tmp:exec --rm $IMAGE `
   docker exec --user root $ID groupadd -f -g $GROUPID $GROUP
   docker exec --user root $ID adduser --shell /bin/bash --uid $UID --gecos '' --ingroup $GROUP --disabled-password --home /home/$USER $USER
   docker exec --user root $ID bash -c "echo $USER ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USER && chmod 0440 /etc/sudoers.d/$USER"


### PR DESCRIPTION
Run a model will cache the compiled executable file to the target path. This will be used to accelerate the start up process when open a new session to run the same model next time.