### PR TITLE
[ONNX] Fix Transpose without `perm` attribute

### DIFF
--- a/tests/unittests/lit_cases/test_dnnl/test_transpose_default_dnnl.cc
+++ b/tests/unittests/lit_cases/test_dnnl/test_transpose_default_dnnl.cc
@@ -25,5 +25,5 @@
 // RUN: %t_dnnl.exe 0.0001 0 dnnl %data_path/test_transpose_default | FileCheck %s
 // CHECK: Result Pass
 // clang-format on
-// XFAIL: *
+
 #include "test_transpose_default_dnnl.cc.tmp.main.cc.in"

--- a/tests/unittests/lit_cases/test_popart/test_transpose_default_popart.cc
+++ b/tests/unittests/lit_cases/test_popart/test_transpose_default_popart.cc
@@ -25,5 +25,5 @@
 // RUN: %t_popart.exe 0.0001 0 popart %data_path/test_transpose_default | FileCheck %s
 // CHECK: Result Pass
 // clang-format on
-// XFAIL: *
+
 #include "test_transpose_default_popart.cc.tmp.main.cc.in"

--- a/tests/unittests/lit_cases/test_tensorrt/test_transpose_default_tensorrt.cc
+++ b/tests/unittests/lit_cases/test_tensorrt/test_transpose_default_tensorrt.cc
@@ -25,5 +25,5 @@
 // RUN: %t_tensorrt.exe 0.0001 0 tensorrt %data_path/test_transpose_default | FileCheck %s
 // CHECK: Result Pass
 // clang-format on
-// XFAIL: *
+
 #include "test_transpose_default_tensorrt.cc.tmp.main.cc.in"

--- a/tests/unittests/lit_cases/test_xnnpack/test_transpose_default_xnnpack.cc
+++ b/tests/unittests/lit_cases/test_xnnpack/test_transpose_default_xnnpack.cc
@@ -25,5 +25,5 @@
 // RUN: %t_xnnpack.exe 0.0001 0 xnnpack %data_path/test_transpose_default | FileCheck %s
 // CHECK: Result Pass
 // clang-format on
-// XFAIL: *
+
 #include "test_transpose_default_xnnpack.cc.tmp.main.cc.in"


### PR DESCRIPTION
If perm is unspecified, ONNX assumes all axes are reversed.