### PR TITLE
[CI] Fix random build error

### DIFF
--- a/.github/actions/build/build_in_docker.sh
+++ b/.github/actions/build/build_in_docker.sh
@@ -23,7 +23,7 @@ CONTAINER_NAME="halo.ci-$VER-$VARIANT"
 docker_run_flag=""
 cmake_flags="-DDNNL_COMPILER=gcc-10"
 check_cmds="parallel -k --plus LIT_NUM_SHARDS={##}  LIT_RUN_SHARD={#}  CUDA_VISIBLE_DEVICES={} ninja check-halo ::: {0..1}"
-check_cmds="$check_cmds && parallel -k --plus LIT_NUM_SHARDS={##}  LIT_RUN_SHARD={#}  CUDA_VISIBLE_DEVICES={} ninja check-halo-models ::: {0..1}"
+check_cmds="$check_cmds && ninja FileCheck && parallel -k --plus LIT_NUM_SHARDS={##}  LIT_RUN_SHARD={#}  CUDA_VISIBLE_DEVICES={} ninja check-halo-models ::: {0..1}"
 
 if [[ "$VARIANT" =~ cuda ]]; then
   docker_run_flag="--runtime=nvidia"


### PR DESCRIPTION
Avoid building FileCheck during parallel jobs

Both "ninja check-halo" jobs will build FileCheck, which causes race condition.
