### PR TITLE
[ODLA/DNNL] Refactor for memory type tracking

### DIFF
--- a/ODLA/platforms/dnnl/odla_dnnl.cc
+++ b/ODLA/platforms/dnnl/odla_dnnl.cc
@@ -153,14 +153,8 @@ odla_status odla_ExecuteComputation(odla_computation comp, odla_context context,
   for (auto& output_pair : outputs_v) {
     auto& src_val = output_pair.second.first;
     auto& dst_ptr = output_pair.second.second;
-    auto elem_size = src_val->elem_size;
-    auto dt = src_val->mem.get_desc().data_type();
-    if (dt == dnnl::memory::data_type::s8 ||
-        dt == dnnl::memory::data_type::u8) {
-      elem_size = 1;
-    }
-    memcpy(dst_ptr, src_val->mem.get_data_handle(),
-           GetTotalElements(src_val->shape) * elem_size);
+    auto len = getValueStorageSize(src_val);
+    memcpy(dst_ptr, src_val->mem.get_data_handle(), len);
   }
   return ODLA_SUCCESS;
 }
@@ -202,9 +196,7 @@ odla_value odla_CreateArgument(odla_value_type type, const odla_value_id id) {
   dnnl::memory::desc md = getMemoryDesc(type);
   dnnl::memory mem = dnnl::memory(md, g_comp->eng);
   odla_value v = CreateValue(mem, type.shape, id);
-  if (type.element_type == ODLA_INT64 || type.element_type == ODLA_FLOAT64) {
-    v->elem_size = 8;
-  }
+  v->elem_type = type.element_type;
   g_comp->inputs[name] = v;
   g_comp->input_vals.push_back(v);
   return v;
@@ -236,20 +228,8 @@ odla_value odla_CreateValue(odla_value_type type, const odla_value_id id) {
 
 odla_status odla_GetValueType(const odla_value value,
                               odla_value_type* value_type) {
-  switch (value->elem_size) {
-    case 1:
-      value_type->element_type = ODLA_INT8;
-      break;
-    case 2:
-      value_type->element_type = ODLA_INT16;
-      break;
-    case 4:
-      value_type->element_type = ODLA_FLOAT32;
-      break;
-    default:
-      value_type->element_type = ODLA_INT64;
-  }
   value_type->shape = value->shape;
+  value_type->element_type = value->elem_type;
   return ODLA_SUCCESS;
 }
 
@@ -309,10 +289,7 @@ odla_value odla_CreateConstant(odla_value_type type, const void* ptr,
 
   odla_value v = CreateValue(mem, type.shape, id);
   v->is_const = true;
-  if (type.element_type == ODLA_INT64 || type.element_type == ODLA_FLOAT64) {
-    v->elem_size = 8;
-  }
-
+  v->elem_type = type.element_type;
   return v;
 }
 
@@ -368,10 +345,7 @@ odla_status odla_BindToOutput(odla_value value, odla_void* data_ptr,
                               odla_context context) {
   // Handle the case of output is constant due to compile-time optimization.
   if (value->is_const) {
-    size_t len = value->mem.get_desc().get_size();
-    if (value->elem_size == 8) {
-      len *= 2;
-    }
+    size_t len = getValueStorageSize(value);
     memcpy(data_ptr, value->mem.get_data_handle(), len);
   } else {
     auto name = value->name;
@@ -473,7 +447,7 @@ odla_value odla_Gather(odla_value params, const odla_value indices,
         outer_size, byte_size, ret_mem, one_batch_byte_size, axis]() {
     int32_t* indices_ptr = (int32_t*)indices->mem.get_data_handle();
     std::vector<int> indices_i32;
-    if (indices->elem_size == 8) {
+    if (getElementStorageSize(indices->elem_type) == 8) {
       int64_t* src = (int64_t*)indices_ptr;
       indices_i32.insert(indices_i32.begin(), src, src + idx_size);
       indices_ptr = indices_i32.data();
@@ -636,6 +610,7 @@ static odla_value binary_eltwise(dnnl::algorithm algo, odla_value lhs,
                 {DNNL_ARG_DST, ret_mem}});
 
   odla_value v = CreateValue(ret_mem, lhs->shape, id);
+  v->elem_type = lhs->elem_type;
   InterpretIfNeeded();
   return v;
 }
@@ -1073,6 +1048,7 @@ static odla_value BasePool(odla_value input, odla_memory_layout input_layout,
 
   add_op(prim, {{DNNL_ARG_SRC, input->mem}, {DNNL_ARG_DST, ret_mem}});
   odla_value v = CreateValue(ret_mem, orig_output_dims, value_id);
+  v->elem_type = input->elem_type;
   InterpretIfNeeded();
   return v;
 }
@@ -1577,7 +1553,7 @@ odla_value odla_Slice(odla_value input, const odla_uint32* start,
     auto prim = dnnl::reorder(src_mem, dst_mem);
     add_op(prim, {{DNNL_ARG_FROM, input->mem}, {DNNL_ARG_TO, dst_mem}});
   } else {
-    int elem_size = GetDataSize(type);
+    int elem_size = getElementStorageSize(input->elem_type);
     auto op = [=]() {
       strided_slice(input->mem.get_data_handle(), elem_size, input_dims, start,
                     end, strides, dst_mem.get_data_handle(), output_dims);

--- a/ODLA/platforms/dnnl/odla_dnnl.h
+++ b/ODLA/platforms/dnnl/odla_dnnl.h
@@ -42,12 +42,16 @@ void InterpretIfNeeded() __attribute__((visibility("hidden")));
 struct _odla_value {
   dnnl::memory mem;
   bool is_const;
-  uint8_t elem_size;
+  odla_element_type elem_type; // TODO: use odla_value_type
   odla_value_shape shape;
   std::string name;
   _odla_value(const dnnl::memory& m, const odla_value_shape& shape_,
               const std::string& id)
-      : mem(m), is_const(false), shape(shape_), name(id), elem_size(4) {
+      : mem(m),
+        is_const(false),
+        shape(shape_),
+        name(id),
+        elem_type(ODLA_FLOAT32) {
     if (shape.size == 0) {
       shape.size = 1;
       shape.dims[0] = 1;
@@ -133,19 +137,9 @@ static inline dnnl::memory::format_tag getFormatTag(odla_memory_layout layout,
   }
 }
 
-static inline int GetDataSize(dnnl::memory::data_type dt) {
-  switch (dt) {
-    case dnnl::memory::data_type::u8:
-    case dnnl::memory::data_type::s8:
-      return 1;
-    case dnnl::memory::data_type::bf16:
-      return 2;
-    case dnnl::memory::data_type::f32:
-    case dnnl::memory::data_type::s32:
-      return 4;
-  }
-  assert(0 && "invalid data type");
-  return 0;
+static inline int64_t GetTotalElements(const odla_value_shape& dims) {
+  return std::accumulate(dims.dims, dims.dims + dims.size, 1,
+                         std::multiplies<size_t>());
 }
 
 static inline dnnl::memory::data_type getDataType(const odla_element_type ty) {
@@ -167,13 +161,57 @@ static inline dnnl::memory::data_type getDataType(const odla_element_type ty) {
     case ODLA_INT64:
       dt = dnnl::memory::data_type::s32; // FIXME:
       break;
+    case ODLA_FLOAT16:
     case ODLA_BFLOAT16:
       dt = dnnl::memory::data_type::bf16;
+      break;
+    case ODLA_STRING:
+      dt = dnnl::memory::data_type::u8; // Actual storage is pointer but DNNL
+      // has no word-sized type.
       break;
     default:
       dt = dnnl::memory::data_type::undef;
   }
   return dt;
+}
+
+static inline size_t getElementStorageSize(odla_element_type elem_type) {
+  switch (elem_type) {
+    case ODLA_FLOAT64:
+    case ODLA_INT64:
+    case ODLA_UINT64:
+    case ODLA_QINT64:
+    case ODLA_QUINT64:
+      return sizeof(int64_t);
+    case ODLA_FLOAT32:
+    case ODLA_QINT32:
+    case ODLA_QUINT32:
+    case ODLA_INT32:
+    case ODLA_UINT32:
+      return sizeof(int32_t);
+    case ODLA_FLOAT16:
+    case ODLA_BFLOAT16:
+    case ODLA_INT16:
+    case ODLA_UINT16:
+    case ODLA_QINT16:
+    case ODLA_QUINT16:
+      return sizeof(uint16_t);
+    case ODLA_INT8:
+    case ODLA_UINT8:
+    case ODLA_QINT8:
+    case ODLA_QUINT8:
+    case ODLA_BOOL:
+      return sizeof(char);
+    case ODLA_STRING:
+      return sizeof(char*);
+  }
+  assert(0 && "Unhandled data type");
+  return 0;
+}
+
+static inline size_t getValueStorageSize(odla_value value) {
+  return GetTotalElements(value->shape) *
+         getElementStorageSize(value->elem_type);
 }
 
 static inline dnnl::memory::desc getMemoryDesc(const odla_value_shape& dims,
@@ -188,11 +226,6 @@ static inline dnnl::memory::desc getMemoryDesc(const odla_value_shape& dims,
 
 static inline dnnl::memory::desc getMemoryDesc(const odla_value_type& ty) {
   return getMemoryDesc(ty.shape, ty.element_type);
-}
-
-static inline int64_t GetTotalElements(const odla_value_shape& dims) {
-  return std::accumulate(dims.dims, dims.dims + dims.size, 1,
-                         std::multiplies<size_t>());
 }
 
 // The strides used by DNNL's memory desc.

--- a/ODLA/platforms/dnnl/odla_dnnl_statistics.cc
+++ b/ODLA/platforms/dnnl/odla_dnnl_statistics.cc
@@ -180,7 +180,7 @@ odla_value odla_CumSum(odla_value input, odla_value axis, odla_bool exclusion,
   auto dt = input->mem.get_desc().data_type();
   auto ret_md = getMemoryDesc(shape, dt);
   assert(dt == dnnl::memory::data_type::f32);
-  bool is_double = input->elem_size == 8 && dt == dnnl::memory::data_type::f32;
+  bool is_double = input->elem_type == ODLA_FLOAT64;
   auto ret_mem =
       is_double ? dnnl::memory(ret_md, g_comp->eng,
                                g_comp->CreateBuffer(elem_n * sizeof(double)))
@@ -205,9 +205,7 @@ odla_value odla_CumSum(odla_value input, odla_value axis, odla_bool exclusion,
   add_op(op);
   InterpretIfNeeded();
   odla_value v = CreateValue(ret_mem, input->shape, id);
-  if (input->elem_size == 8) {
-    v->elem_size = 8;
-  }
+  v->elem_type = input->elem_type;
   return v;
 }
 
@@ -281,9 +279,7 @@ static odla_value arg_min_max(bool is_arg_max, odla_value input,
   add_op(op);
   InterpretIfNeeded();
   auto v = CreateValue(dst_mem, output_value_type.shape, value_id);
-  if (output_value_type.element_type == ODLA_INT64) {
-    v->elem_size = 8;
-  }
+  v->elem_type = output_value_type.element_type;
   return v;
 }
 

--- a/tests/unittests/lit_cases/test_dnnl/test_max_float16_dnnl.cc
+++ b/tests/unittests/lit_cases/test_dnnl/test_max_float16_dnnl.cc
@@ -26,5 +26,5 @@
 // RUN: %t_dnnl.exe 0.0001 0 dnnl %data_path/test_max_float16 | FileCheck %s
 // CHECK: Result Pass
 // clang-format on
-// XFAIL: *
+
 #include "test_max_float16_dnnl.cc.tmp.main.cc.in"

--- a/tests/unittests/lit_cases/test_dnnl/test_min_float16_dnnl.cc
+++ b/tests/unittests/lit_cases/test_dnnl/test_min_float16_dnnl.cc
@@ -26,5 +26,5 @@
 // RUN: %t_dnnl.exe 0.0001 0 dnnl %data_path/test_min_float16 | FileCheck %s
 // CHECK: Result Pass
 // clang-format on
-// XFAIL: *
+
 #include "test_min_float16_dnnl.cc.tmp.main.cc.in"


### PR DESCRIPTION
dnnl::memory only supports few data types. We need to track the actual
data type in odla_value.