### PR TITLE
fix on default configuration & computation destroyment

### DIFF
--- a/ODLA/platforms/odla_popart/odla_compute.cc
+++ b/ODLA/platforms/odla_popart/odla_compute.cc
@@ -112,11 +112,7 @@ odla_status odla_DestroyContext(odla_context ctx) {
 
 odla_status odla_DestroyComputation(odla_computation comp) {
   comp->mark_done();
-  if (comp->session != nullptr) {
-    comp->session->getDevice().getDeviceInfo()->detach();
-    comp->session.reset();
-    assert(comp->session == nullptr);
-  }
+  _odla_computation::destruct();
   return ODLA_SUCCESS;
 }
 
@@ -178,7 +174,7 @@ odla_status odla_BindToArgument(odla_value value, const odla_void* data_ptr,
   // only the SEQUENCE model need to pass the data in once time
   if (PopartConfig::instance()->execution_mode() == SEQUENCE &&
       shape.size() > 0)
-    shape[0] *= PopartConfig::instance()->batches_per_step();
+    shape[0] *= g_comp->opts.batches_per_step;
   std::unique_ptr<popart::IArray> p_array = MakeNDArrayWrapper(
       data_ptr, context->comp->builder->getTensorDataType(value->tensor_id),
       shape);
@@ -236,7 +232,7 @@ odla_status odla_BindToOutput(odla_value value, odla_void* data_ptr,
   // only the SEQUENCE model need to pass the data in once time
   if (PopartConfig::instance()->execution_mode() == SEQUENCE &&
       shape.size() > 0)
-    shape[0] *= PopartConfig::instance()->batches_per_step();
+    shape[0] *= g_comp->opts.batches_per_step;
   std::unique_ptr<popart::IArray> p_array = MakeNDArrayWrapper(
       data_ptr, context->comp->builder->getTensorDataType(value->tensor_id),
       shape);

--- a/ODLA/platforms/odla_popart/odla_popart.cc
+++ b/ODLA/platforms/odla_popart/odla_popart.cc
@@ -31,8 +31,6 @@
 #include "onnx/onnx.pb.h"
 #include "popart_config.h"
 
-_odla_computation* _odla_computation::instance_ = new _odla_computation();
-
 void compute_loop(odla_computation comp) {
   // setup the stepio with allbacks
   popart::StepIOCallback stepio(input_callback, input_complete_callback,
@@ -58,14 +56,14 @@ void compute_loop(odla_computation comp) {
     popart::logging::warn("Found new tasks in {} ms.", elapsed_ms.count());
   }
   popart::logging::warn("The pipeline loop finished");
-  comp->thread_complete_ = true;
+  comp->thread_done();
 }
 
 void _odla_computation::init() {
   if (!session) {
     std::lock_guard<std::mutex> guard(init_mutex_);
     if (!session) {
-      set_opts(); // Test code
+      set_opts();
       // Cretate the dataflow
       std::vector<popart::TensorId> ids;
       for (const auto& output : outputs_map)
@@ -111,6 +109,7 @@ void _odla_computation::init() {
       ExecutionMode mode = PopartConfig::instance()->execution_mode();
       if (PIPELINE == mode || PARALLEL == mode) {
         std::thread parallel_thread(compute_loop, this);
+        thread_state_ = RUNNING;
         popart::logging::warn("Parallel loop has been started");
         parallel_thread.detach();
       }
@@ -125,7 +124,7 @@ void _odla_computation::set_opts() {
   if (PopartConfig::instance()->debug()) {
     opts.ipu_num = PopartConfig::instance()->ipu_num();
     opts.batches_per_step = PopartConfig::instance()->batches_per_step();
-  } else {
+  } else if (use_pipeline()) { // Only check when use pipeline
     if (opts.ipu_num != PopartConfig::instance()->ipu_num())
       throw std::invalid_argument(
           "number of ipus in pipeline configuration:" +

--- a/ODLA/platforms/odla_popart/odla_popart.cc
+++ b/ODLA/platforms/odla_popart/odla_popart.cc
@@ -31,6 +31,9 @@
 #include "onnx/onnx.pb.h"
 #include "popart_config.h"
 
+_odla_computation* _odla_computation::instance_ = nullptr;
+std::mutex _odla_computation::comp_mutex_;
+
 void compute_loop(odla_computation comp) {
   // setup the stepio with allbacks
   popart::StepIOCallback stepio(input_callback, input_complete_callback,

--- a/ODLA/platforms/odla_popart/odla_popart.h
+++ b/ODLA/platforms/odla_popart/odla_popart.h
@@ -24,6 +24,7 @@
 #include <atomic>
 #include <condition_variable>
 #include <popart/builder.hpp>
+#include <popart/popx/devicex.hpp>
 #include <popart/session.hpp>
 #include <popart/sessionoptions.hpp>
 #include <popart/tensorinfo.hpp>
@@ -90,10 +91,29 @@ struct _odla_computation {
   target_opts opts;
 
   // new members for pipeline
+  enum THREAD_STATE { RUNNING = 0, MARK_DONE, DONE };
+  THREAD_STATE thread_state_;
+  std::mutex thread_done_mutex_;
+  std::condition_variable thread_done_cv_;
+
   static _odla_computation* instance_;
+  static std::mutex comp_mutex_;
   static _odla_computation* instance(bool hold_it = true) {
+    if (instance_ == nullptr) {
+      std::lock_guard<std::mutex> guard(comp_mutex_);
+      if (instance_ == nullptr) instance_ = new _odla_computation();
+    }
     if (hold_it) instance_->hold();
     return instance_;
+  }
+  static void destruct() {
+    if (instance_ != nullptr) {
+      std::lock_guard<std::mutex> guard(comp_mutex_);
+      if (instance_ != nullptr) {
+        delete instance_;
+        instance_ = nullptr;
+      }
+    }
   }
   bool done_;
   bool thread_complete_;
@@ -108,12 +128,10 @@ struct _odla_computation {
         opts({false, 1, 1}),
         done_(false),
         executor_(nullptr),
-        thread_complete_(false) {
+        thread_state_(DONE) {
     builder->setAttribute(popart::sVirtualGraphAttribute, 0);
   }
   void init();
-  inline bool is_done() { return done_; }
-  inline void mark_done() { done_ = true; }
   std::string set_pipeline_stage();
   void set_session_opts();
   void set_executor();
@@ -121,6 +139,26 @@ struct _odla_computation {
   bool use_pipeline();
   bool hold();
   inline Execution* executor() { return executor_; }
+  inline bool is_done() { return thread_state_ != RUNNING; }
+  inline void mark_done() {
+    while (thread_state_ != DONE) {
+      std::unique_lock<std::mutex> lock(thread_done_mutex_);
+      thread_state_ = MARK_DONE;
+      thread_done_cv_.wait_for(lock, std::chrono::milliseconds(1000));
+    }
+    // Once get notified, only detach the device once
+    std::lock_guard<std::mutex> guard(init_mutex_);
+    if (session != nullptr) {
+      session->getDevice().getDeviceInfo()->detach();
+      session.reset();
+      assert(session == nullptr);
+    }
+  }
+  inline void thread_done() {
+    std::unique_lock<std::mutex> lock(thread_done_mutex_);
+    thread_state_ = DONE;
+    thread_done_cv_.notify_all();
+  }
 };
 
 struct _odla_context {


### PR DESCRIPTION
Fixed the following parts:

1. Fixed the problem of default setting of ipu_num, batch_per_step etc set by popart_config.cc were used, which caused the parameters set did not take effect.
    - Make the popart_config.cc set only take effect for pipeline to check whether the configuration consistent or not.
2. Fixed the problem of multiple device detach called, or device detach called during the pipeline is executing, which will cause the poplar exception or even exit.
    - Add status checking for the computation destroy call, make the multiple call in sequence. And make it wait for the pipeline stage terminate(usually it takes less than 1s, it depends on the configuration of batches per step)
3. Fixed the problem computation destroy
    - Make the singleton odla_computation from hungry to lazy
    - Add destruct to delete the instance of odla_computation and set the static pointer to null