### PR TITLE
Add int64 attribute type

### DIFF
--- a/include/halo/lib/ir/attribute_types.td
+++ b/include/halo/lib/ir/attribute_types.td
@@ -24,6 +24,7 @@ include "value_type.td"
 let is_integer_ = 1 in {
   def Bool : ValueType<1, "bool">;
   def Integer : ValueType<32, "int">;
+  def Integer64 : ValueType<64, "int64_t">;
   def BoolList : ValueType<1, "std::vector<bool>"> { let is_array_ = 1; }
   def IntegerList : ValueType<32, "std::vector<int>"> { let is_array_ = 1; }
   def IntegerListList : ValueType<64, "std::vector<std::vector<int64_t>>"> { let is_2d_array_ = 1;}

--- a/lib/parser/onnx/onnx_parser.cc
+++ b/lib/parser/onnx/onnx_parser.cc
@@ -224,7 +224,7 @@ Status ONNXParser::ConvertToHaloIR(const onnx::GraphProto& graph_def) {
           case DataType::INT64: {
             const Tensor<int64_t> temp = ProcessTensor<int64_t>(tensor_def);
             HLCHECK(temp.GetShape().size() == 1 && temp.GetShape()[0] == 1);
-            attr_val = Attribute::CreateInteger("value", temp.GetData()[0]);
+            attr_val = Attribute::CreateInteger64("value", temp.GetData()[0]);
             break;
           }
           default:


### PR DESCRIPTION
Special ops like ConstantOfShape uses tensor to represent the value to
fill, so we need correspoding value type.