### PR TITLE
[ONNX] Bugfix for Slice op leglization.

### DIFF
--- a/lib/transforms/onnxextension_legalizer.cc
+++ b/lib/transforms/onnxextension_legalizer.cc
@@ -566,12 +566,23 @@ static std::vector<Def> ConvertSlice(const ONNXExtensionInst* ext,
         builder->CreateSub(ext->GetName() + "_len", op_ends, op_starts);
     std::vector<Def> ops{op0, op_starts, *op_len};
 
+    // Operand [step]: if no step, set step=1
+    if (ext->GetNumOfOperands() > 4) {
+      ops.push_back(ext->GetOperand(4));
+    } else {
+      int start_size = op_starts.GetType().GetTotalNumOfElements();
+      std::vector<int> steps(input_type.GetNumOfDims(), 1);
+      Constant* c_steps =
+          cb.CreateConstant(ext->GetName() + "_steps",
+                            Type{DataType::INT32, {start_size}}, steps.data());
+      ops.push_back(*c_steps);
+    }
+
+    // Operand [axes]
     if (ext->GetNumOfOperands() >= 4) {
       ops.push_back(ext->GetOperand(3));
     }
-    if (ext->GetNumOfOperands() > 4) {
-      ops.push_back(ext->GetOperand(4));
-    }
+
     SliceInst* slice = builder->CreateSlice(ext->GetName(), ops);
     return {*slice};
   }


### PR DESCRIPTION
  * When 'starts' or 'end' is non constant, currently the order of
   'step' and 'axes' is wrongly handled.
  * If 'step' is not set, then set 'step' to {1}.