### PR TITLE
[Fix] slice with dynamic batch

### DIFF
--- a/lib/transforms/inst_simplify.cc
+++ b/lib/transforms/inst_simplify.cc
@@ -2324,9 +2324,10 @@ std::pair<Def, Def> InstSimplify::RunOnInstruction(SliceInst* inst) {
     std::vector<int> size_adj(dim);
     bool new_size = false;
     for (int i = 0; i != dim; ++i) {
-      int size_i = c_size->GetDataAsInt64(i);
-      if (size_i == -1) {
-        size_adj[i] = dst_type.GetNumOfElementsInDim(i);
+      int64_t size_i = c_size->GetDataAsInt64(i);
+      int64_t s = dst_type.GetNumOfElementsInDim(i);
+      if (size_i == -1 && s != -1) {
+        size_adj[i] = s;
         new_size = true;
       } else {
         size_adj[i] = size_i;


### PR DESCRIPTION
When the length operand of slice is -1, it means taking all elements on
that dimension. Originally, inst simplification pass attemps to replace
-1 with actual dimension size.
However, -1 is also used to represent dynamic size, so it will make the
pass keep running.