### PR TITLE
Add epsilon to LpNorm

### DIFF
--- a/ODLA/include/ODLA/ops/odla_ops_math.h
+++ b/ODLA/include/ODLA/ops/odla_ops_math.h
@@ -648,15 +648,16 @@ odla_Reciprocal(odla_value input, const odla_value_id value_id);
   \param num_of_axes nubmer of axes to reduce
   \param axes the axes to reduce
   \param keep_dims keep the reduced dimension or not
+  \param epsilon use to avoid division by zero
   \param output_dims the optional output shape (can be undefined)
   \param value_id a unique value id (can be NULL)
 
   \return odla_value
 */
-extern ODLA_API_EXPORT odla_value ODLA_API_CALL
-odla_ReduceL1(odla_value input, odla_size_t num_of_axes,
-              const odla_uint32* axes, odla_bool keep_dims,
-              odla_value_shape output_dims, const odla_value_id value_id);
+extern ODLA_API_EXPORT odla_value ODLA_API_CALL odla_ReduceL1(
+    odla_value input, odla_size_t num_of_axes, const odla_uint32* axes,
+    odla_bool keep_dims, odla_float32 epsilon, odla_value_shape output_dims,
+    const odla_value_id value_id);
 
 //! \brief Compute the L2 norm alone axes
 /*!
@@ -666,15 +667,16 @@ odla_ReduceL1(odla_value input, odla_size_t num_of_axes,
   \param num_of_axes nubmer of axes to reduce
   \param axes the axes to reduce
   \param keep_dims keep the reduced dimension or not
+  \param epsilon use to avoid division by zero
   \param output_dims the optional output shape (can be undefined)
   \param value_id a unique value id (can be NULL)
 
   \return odla_value
 */
-extern ODLA_API_EXPORT odla_value ODLA_API_CALL
-odla_ReduceL2(odla_value input, odla_size_t num_of_axes,
-              const odla_uint32* axes, odla_bool keep_dims,
-              odla_value_shape output_dims, const odla_value_id value_id);
+extern ODLA_API_EXPORT odla_value ODLA_API_CALL odla_ReduceL2(
+    odla_value input, odla_size_t num_of_axes, const odla_uint32* axes,
+    odla_bool keep_dims, odla_float32 epsilon, odla_value_shape output_dims,
+    const odla_value_id value_id);
 
 //! \brief Compute the log sum alone axes
 /*!

--- a/ODLA/platforms/dnnl/odla_dnnl_statistics.cc
+++ b/ODLA/platforms/dnnl/odla_dnnl_statistics.cc
@@ -47,16 +47,18 @@ static odla_value reduce_op(dnnl::algorithm alg, odla_value input,
 
 odla_value odla_ReduceL1(odla_value input, odla_size_t num_of_axes,
                          const odla_uint32* axes, odla_bool keep_dims,
-                         odla_value_shape output_dims, const odla_value_id id) {
+                         odla_float32 epsilon, odla_value_shape output_dims,
+                         const odla_value_id id) {
   return reduce_op(dnnl::algorithm::reduction_norm_lp_sum, input, num_of_axes,
-                   axes, keep_dims, output_dims, id, 1 /* P */);
+                   axes, keep_dims, output_dims, id, 1 /* P */, epsilon);
 }
 
 odla_value odla_ReduceL2(odla_value input, odla_size_t num_of_axes,
                          const odla_uint32* axes, odla_bool keep_dims,
-                         odla_value_shape output_dims, const odla_value_id id) {
+                         odla_float32 epsilon, odla_value_shape output_dims,
+                         const odla_value_id id) {
   return reduce_op(dnnl::algorithm::reduction_norm_lp_sum, input, num_of_axes,
-                   axes, keep_dims, output_dims, id, 2 /* P */);
+                   axes, keep_dims, output_dims, id, 2 /* P */, epsilon);
 }
 
 odla_value odla_ReduceLogSum(odla_value input, odla_size_t num_of_axes,

--- a/ODLA/platforms/tensorrt/odla_tensorrt.cc
+++ b/ODLA/platforms/tensorrt/odla_tensorrt.cc
@@ -1388,7 +1388,8 @@ static odla_value reduce(odla_value input, nvinfer1::ReduceOperation op,
 
 odla_value odla_ReduceL1(odla_value input, odla_size_t num_of_axes,
                          const odla_uint32* axes, odla_bool keep_dims,
-                         odla_value_shape output_dims, const odla_value_id id) {
+                         float epsilon, odla_value_shape output_dims,
+                         const odla_value_id id) {
   const auto& name = std::string(reinterpret_cast<const char*>(id)) + "_extra";
   return reduce(odla_Abs(input, (const odla_value_id)name.c_str()),
                 nvinfer1::ReduceOperation::kSUM, num_of_axes, axes, keep_dims,
@@ -1397,7 +1398,8 @@ odla_value odla_ReduceL1(odla_value input, odla_size_t num_of_axes,
 
 odla_value odla_ReduceL2(odla_value input, odla_size_t num_of_axes,
                          const odla_uint32* axes, odla_bool keep_dims,
-                         odla_value_shape output_dims, const odla_value_id id) {
+                         float epsilon, odla_value_shape output_dims,
+                         const odla_value_id id) {
   const auto& name = std::string(reinterpret_cast<const char*>(id)) + "_extra";
   return odla_Sqrt(
       odla_ReduceSumSquare(input, num_of_axes, axes, keep_dims, output_dims,

--- a/include/halo/lib/ir/common_reduction_instructions.td
+++ b/include/halo/lib/ir/common_reduction_instructions.td
@@ -24,18 +24,27 @@ let cat_ = cat_common_reduction,
     attrs_ = [Attr<"Axis along which to reduce, omitted if X2 exists.",
                    IntegerList, "axis">,
               Attr<"Indicate whether to keep the reduced dimension.",
-                   Bool, "keep_dims", "true">],
+                   Bool, "keep_dims", "true">,
+              Attr<"Use to avoid division by zero.",
+                   Float, "epsilon", "0">,
+    ],
+    ins_ = [Arg<"The input.", ArgType<[I8,I16,I32,F16,F32]> >,
+              OptionalArg<"The axis.", ArgType<[I32]>, 1D>],
     outs_ = [Arg<"The result", MatchArgType<0> >] in {
-
-  let ins_ = [Arg<"The input.", ArgType<[I8,I16,I32,F16,F32]> >,
-              OptionalArg<"The axis.", ArgType<[I32]>, 1D>] in {
-
-    def ReduceL1 : Inst<"Computes the L1 norm of the elements across"
+      def ReduceL1 : Inst<"Computes the L1 norm of the elements across"
                         " dimensions.">;
-
-    def ReduceL2 : Inst<"Compute the L2 norm of the elements across"
+      def ReduceL2 : Inst<"Compute the L2 norm of the elements across"
                         " dimensions.">;
+    }
 
+let cat_ = cat_common_reduction,
+    attrs_ = [Attr<"Axis along which to reduce, omitted if X2 exists.",
+                   IntegerList, "axis">,
+              Attr<"Indicate whether to keep the reduced dimension.",
+                   Bool, "keep_dims", "true">],
+    ins_ = [Arg<"The input.", ArgType<[I8,I16,I32,F16,F32]> >,
+              OptionalArg<"The axis.", ArgType<[I32]>, 1D>],
+    outs_ = [Arg<"The result", MatchArgType<0> >] in {
     def ReduceLogSum : Inst<"Compute the log sum of the elements across"
                             " dimensions.">;
 
@@ -59,7 +68,6 @@ let cat_ = cat_common_reduction,
 
     def ReduceSum : Inst<"Compute the sum of the elements across"
                          " dimensions">;
-  }
 
   /* def ReduceAll : Inst<"Compute the logical AND of the elements across"
                        " dimensions."> {
@@ -83,7 +91,6 @@ let cat_ = cat_common_reduction,
 
   def Argmin : Inst<"Computes the indices of the smallest value of the input"
                     " along the specified axis.">;
-
 }
 
 let cat_ = cat_common_reduction in {

--- a/include/halo/lib/target/generic_cxx/generic_cxx_codegen.h
+++ b/include/halo/lib/target/generic_cxx/generic_cxx_codegen.h
@@ -212,7 +212,8 @@ class GenericCXXCodeGen : public CodeGen {
   virtual void RunOnReductionInstruction(Instruction*,
                                          const std::vector<int32_t>& axis_attr,
                                          bool keep_dims,
-                                         const char* odla_func_name);
+                                         const std::string& odla_func_name,
+                                         float epsilon = 0);
   virtual void RunOnUnaryInstruction(Instruction*);
   virtual void RunOnBranchBody(const IfInst& inst, bool is_taken);
 

--- a/lib/target/generic_cpp/reduction.cc
+++ b/lib/target/generic_cpp/reduction.cc
@@ -21,7 +21,7 @@ namespace halo {
 
 void GenericCXXCodeGen::RunOnReductionInstruction(
     Instruction* inst, const std::vector<int32_t>& axis_attr, bool keep_dims,
-    const char* odla_func_name) {
+    const std::string& odla_func_name, float eps) {
   const Def& input = inst->GetOperand(0);
 
   CXXValue op0 = ir_mapping_[input];
@@ -40,9 +40,13 @@ void GenericCXXCodeGen::RunOnReductionInstruction(
       axis.push_back(i);
     }
   }
-
-  EmitODLACall(ret, odla_func_name, op0, axis.size(), axis, keep_dims,
-               EmitShape(ret_type));
+  if (odla_func_name == "odla_ReduceL1" || odla_func_name == "odla_ReduceL2") {
+    EmitODLACall(ret, odla_func_name.c_str(), op0, axis.size(), axis, keep_dims,
+                 eps, EmitShape(ret_type));
+  } else {
+    EmitODLACall(ret, odla_func_name.c_str(), op0, axis.size(), axis, keep_dims,
+                 EmitShape(ret_type));
+  }
   ir_mapping_[*inst] = ret;
 }
 
@@ -63,12 +67,12 @@ void GenericCXXCodeGen::RunOnInstruction(ReduceMaxInst* inst) {
 
 void GenericCXXCodeGen::RunOnInstruction(ReduceL1Inst* inst) {
   RunOnReductionInstruction(inst, inst->GetAxis(), inst->GetKeepDims(),
-                            "odla_ReduceL1");
+                            "odla_ReduceL1", inst->GetEpsilon());
 }
 
 void GenericCXXCodeGen::RunOnInstruction(ReduceL2Inst* inst) {
   RunOnReductionInstruction(inst, inst->GetAxis(), inst->GetKeepDims(),
-                            "odla_ReduceL2");
+                            "odla_ReduceL2", inst->GetEpsilon());
 }
 
 void GenericCXXCodeGen::RunOnInstruction(ReduceProductInst* inst) {


### PR DESCRIPTION
To avoid possible divid by zero, Caffe Norm has a epsilon value.