### PR TITLE
Support emitting .bin file of other target

### DIFF
--- a/driver/driver.cc
+++ b/driver/driver.cc
@@ -382,7 +382,6 @@ int main(int argc, char** argv) {
   cg_opts.constant_decombine = ConstantDecombine;
 
   if (is_c_or_cxx_output) {
-    ctx.SetTargetTriple("x86_64"); // For binary constant writer.
     if (llvm::StringRef(Target).startswith_lower("cc")) {
       cg_opts.dialect = Dialect::C99;
     }

--- a/include/halo/lib/pass/pass_manager.h
+++ b/include/halo/lib/pass/pass_manager.h
@@ -68,6 +68,7 @@ class HL_API_EXPORT PassManager final {
                              std::ostringstream& header,
                              const CXXCodeGenOpts& opts);
   Pass* AddConvertTFCFGPass();
+  Pass* AddConstantWriterPass(std::ostream& os, const std::string& target);
   Pass* AddDCEPass();
   Pass* AddDevicePlacementPass();
   Pass* AddFusionPass(const FusionOptions& opts);
@@ -125,6 +126,7 @@ class HL_API_EXPORT PassManager final {
   Pass* AddX86LLVMIRCodeGenPass();
   Pass* AddX86LLVMIRCodeGenPass(ConstantDataStorage constant_data_storage);
   Pass* AddConstantDecombinePass();
+  GlobalContext& GetGlobalContext() const;
 
  private:
   Pass* Add(std::unique_ptr<ModulePass> pass);

--- a/lib/pass/pass_manager.cc
+++ b/lib/pass/pass_manager.cc
@@ -61,7 +61,7 @@ class PassManagerImpl {
   Pass* Add(std::unique_ptr<FunctionPass> pass);
   Pass* Add(std::unique_ptr<BasicBlockPass> pass);
 
-  GlobalContext& GetGobalContext() { return ctx_; }
+  GlobalContext& GetGlobalContext() { return ctx_; }
 
   Status Run(Module* module);
 
@@ -89,6 +89,10 @@ Pass* PassManager::Add(std::unique_ptr<FunctionPass> pass) {
 
 Pass* PassManager::Add(std::unique_ptr<BasicBlockPass> pass) {
   return impl_->Add(std::move(pass));
+}
+
+GlobalContext& PassManager::GetGlobalContext() const {
+  return impl_->GetGlobalContext();
 }
 
 Status PassManager::Run(Module* module) { return impl_->Run(module); }
@@ -267,6 +271,23 @@ Pass* PassManager::AddCodeFormatterPass(std::ostringstream& buf_code,
 }
 
 Pass* PassManager::AddConvertTFCFGPass() { return AddPass<ConvertTFCFG>(); }
+
+Pass* PassManager::AddConstantWriterPass(std::ostream& os,
+                                         const std::string& target) {
+  auto is_begin_with = [](const std::string& s, const std::string& t) {
+    return s.substr(0, t.size()) == t;
+  };
+  if (is_begin_with(target, "x86_64")) {
+    return AddX86ConstantWriterPass(os);
+  }
+  if (is_begin_with(target, "aarch64")) {
+    return AddARMConstantWriterPass(os);
+  }
+  if (is_begin_with(target, "riscv")) {
+    return AddRISCVConstantWriterPass(os);
+  }
+  return AddGenericCXXConstantWriterPass(os);
+}
 
 Pass* PassManager::AddDCEPass() { return AddPass<DCE>(); }
 


### PR DESCRIPTION
Using -target cxx-<target> to generate .bin file of other target.
For example: -target cxx-aarch64

(cherry picked from commit c86445c913b47045ee286cac57bcb0c7985e4641)