### PR TITLE
odla_popart: add support for graphcore poplar sdk 3.1.0

### DIFF
--- a/.github/actions/build/build_in_docker.sh
+++ b/.github/actions/build/build_in_docker.sh
@@ -34,14 +34,14 @@ cmake_flags="$cmake_flags -DHALO_USE_STATIC_PROTOBUF=ON -DCPACK_SYSTEM_NAME=ubun
 gid=$(id -g ${USER})
 group=$(id -g -n ${USER})
 uid=$(id -u ${USER})
-extra_mnt="-v /opt/poplar_sdk-ubuntu_18_04-2.3.1_793:/opt/poplar_sdk:ro"
+extra_mnt="-v /opt/poplar_sdk-ubuntu_18_04-3.1.0-EA.1+1167-ed39666085:/opt/poplar_sdk:ro"
 mkdir -p /tmp/ubuntu.cache
 extra_mnt="$extra_mnt -v /tmp/ubuntu.cache:/cache"
 
 rm -fr $MOUNT_DIR/output_ubuntu && mkdir -p $MOUNT_DIR/output_ubuntu
-extra_cmd="source /opt/poplar_sdk/poplar/enable.sh" # dummy command
-cmd="cd /build && cmake -G Ninja $cmake_flags /host/halo "
-cmd="$cmd && ninja && $extra_cmd && $check_cmds && ninja package "
+extra_cmd="source /opt/poplar_sdk/poplar/enable.sh && source /opt/poplar_sdk/popart/enable.sh"
+cmd="cd /build && $extra_cmd && cmake -G Ninja $cmake_flags /host/halo "
+cmd="$cmd && ninja && $check_cmds && ninja package "
 cmd="$cmd && cp /build/*.bz2 /host/output_ubuntu"
 docker run -e CCACHE_DIR=/cache $docker_run_flag -v $MOUNT_DIR:/host \
   --tmpfs /build:exec --tmpfs /tmp:exec --entrypoint="" \

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -86,9 +86,9 @@ jobs:
             -v $poplar_sdk:/opt/poplar_sdk:ro \
             -v ${{runner.workspace}}/$repo_name:/host \
             $image_registry/computation/halo:$image_tag \
-            /bin/bash -c 'source scl_source enable devtoolset-7 && cd /build && cmake -G Ninja /host/halo -DHALO_USE_TIDY_CHECK=OFF -DHALO_GEN_DOCS=OFF -DODLA_BUILD_POPART_USE_CXX11ABI=OFF -DODLA_BUILD_POPART_CUSTOM_OPS=ON -DODLA_BUILD_TRT=ON -DODLA_BUILD_XNNPACK=OFF -DODLA_BUILD_EIGEN=ON -DODLA_BUILD_DNNL=ON -DODLA_BUILD_ASCEND=ON -DHALO_BUILD_RTLIB=OFF -DHALO_USE_STATIC_PROTOBUF=ON -DCPACK_SYSTEM_NAME=centos-i686 && ninja && source /opt/poplar_sdk/poplar/enable.sh && ninja check-halo && ninja package && cp /build/*.bz2 /build/*.rpm /host/output_centos'
+            /bin/bash -c 'source scl_source enable devtoolset-7 && cd /build && source /opt/poplar_sdk/poplar/enable.sh && source /opt/poplar_sdk/popart/enable.sh && cmake -G Ninja /host/halo -DHALO_USE_TIDY_CHECK=OFF -DHALO_GEN_DOCS=OFF -DODLA_BUILD_POPART_USE_CXX11ABI=OFF -DODLA_BUILD_POPART_CUSTOM_OPS=ON -DODLA_BUILD_TRT=ON -DODLA_BUILD_XNNPACK=OFF -DODLA_BUILD_EIGEN=ON -DODLA_BUILD_DNNL=ON -DODLA_BUILD_ASCEND=ON -DHALO_BUILD_RTLIB=OFF -DHALO_USE_STATIC_PROTOBUF=ON -DCPACK_SYSTEM_NAME=centos-i686 && ninja && source /opt/poplar_sdk/poplar/enable.sh && ninja check-halo && ninja package && cp /build/*.bz2 /build/*.rpm /host/output_centos'
         env:
-          poplar_sdk: /opt/poplar_sdk-centos_7_6-2.3.1_793
+          poplar_sdk: /opt/poplar_sdk-centos_7_6-3.1.0-EA.1+1168-a2e17bf73e
           repo_name : heterogeneity-aware-lowering-and-optimization
           image_registry : registry-intl.us-west-1.aliyuncs.com
           image_tag : 0.8.1-devel-cuda11.4.2-cudnn8-centos7

--- a/ODLA/platforms/odla_popart/CMakeLists.txt
+++ b/ODLA/platforms/odla_popart/CMakeLists.txt
@@ -23,6 +23,7 @@ if(ENABLE_COVERAGE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage --coverage")
 endif()
 
+set(CMAKE_CXX_FLAGS "-DONNX_NAMESPACE=onnx ${CMAKE_CXX_FLAGS}")
 add_odla_library(odla_popart SHARED common.cc odla_compute.cc
                                odla_ops_math.cc odla_ops_nn.cc
                                odla_ops_process.cc odla_ops.cc
@@ -41,9 +42,6 @@ set(POPART_ROOT ${POPART_ROOT} PARENT_SCOPE)
 
 list(APPEND CMAKE_PREFIX_PATH ${POPLAR_ROOT})
 list(APPEND CMAKE_PREFIX_PATH ${POPART_ROOT})
-find_package(popart 2.3.0... REQUIRED CONFIG COMPONENTS popart-only REQUIRED)
-
-message(STATUS "Found popart, version: ${popart_VERSION}")
 
 if (ODLA_BUILD_POPART_CUSTOM_OPS)
   message(STATUS "Build popart custom op")
@@ -58,7 +56,7 @@ if (NOT ODLA_BUILD_POPART_USE_CXX11ABI)
 endif()
 
 
-target_link_libraries(odla_popart PUBLIC ODLA custom_ops popart-only)
+target_link_libraries(odla_popart PUBLIC ODLA custom_ops popart)
 
 if(ENABLE_COVERAGE)
   target_link_libraries(odla_popart PUBLIC gcov)

--- a/ODLA/platforms/odla_popart/common.cc
+++ b/ODLA/platforms/odla_popart/common.cc
@@ -140,8 +140,8 @@ std::unique_ptr<popart::IArray> MakeNDArrayWrapper(const odla_void* data_ptr,
       break;
     }
     case popart::DataType::FLOAT16: {
-      pArray = std::make_unique<popart::NDArrayWrapper<popart::float16_t>>(
-          reinterpret_cast<popart::float16_t*>(ptr), shape);
+      pArray = std::make_unique<popart::NDArrayWrapper<popart::Half>>(
+          reinterpret_cast<popart::Half*>(ptr), shape);
       break;
     }
     case popart::DataType::UINT32: {

--- a/ODLA/platforms/odla_popart/custom_ops/CMakeLists.txt
+++ b/ODLA/platforms/odla_popart/custom_ops/CMakeLists.txt
@@ -28,7 +28,7 @@ if (NOT ODLA_BUILD_POPART_USE_CXX11ABI)
   target_compile_definitions(custom_ops PRIVATE _GLIBCXX_USE_CXX11_ABI=0)
 endif()
 
-target_link_libraries(custom_ops PRIVATE popart-only)
+target_link_libraries(custom_ops PRIVATE popart)
 target_include_directories(custom_ops PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/third_party/onnx/
    ${CMAKE_CURRENT_SOURCE_DIR}/third_party/include/

--- a/ODLA/platforms/odla_popart/custom_ops/rsqrt.cc
+++ b/ODLA/platforms/odla_popart/custom_ops/rsqrt.cc
@@ -26,6 +26,8 @@
 #include <popart/popx/opx.hpp>
 #include <popart/popx/opxmanager.hpp>
 #include <popops/ElementWise.hpp>
+#include <snap/Graph.hpp>
+#include <snap/Program.hpp>
 #include <vector>
 
 namespace CustomOperators {

--- a/ODLA/platforms/odla_popart/odla_popart.cc
+++ b/ODLA/platforms/odla_popart/odla_popart.cc
@@ -28,6 +28,7 @@
 #include <popart/builder.hpp>
 #include <popart/dataflow.hpp>
 #include <popart/version.hpp>
+#include <popart/session.hpp>
 
 #include "odla_pipeline.h"
 #include "onnx/onnx.pb.h"
@@ -278,7 +279,8 @@ odla_status _odla_computation::init(bool is_compile) {
                 int config_len = 0;
                 cache_fs->read((char*)&config_len, sizeof(config_len));
                 cache_fs->seekg(config_len + sizeof(config_len), std::ios::beg);
-                new_session->loadExecutableFromStream(*(cache_fs.get()));
+                std::shared_ptr<std::istream> in{cache_fs.get()};
+                new_session->loadExecutableFromStream(in);
               } catch (std::exception& e) {
                 popart::logging::err("bad cache file: {}", e.what());
                 return ODLA_FAILURE;

--- a/ODLA/platforms/odla_popart/odla_popart.h
+++ b/ODLA/platforms/odla_popart/odla_popart.h
@@ -23,8 +23,10 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <popart/iarray.hpp>
 #include <popart/builder.hpp>
 #include <popart/popx/devicex.hpp>
+#include <popart/devicemanager.hpp>
 #include <popart/session.hpp>
 #include <popart/sessionoptions.hpp>
 #include <popart/tensorinfo.hpp>

--- a/ODLA/platforms/odla_popart/test/CMakeLists.txt
+++ b/ODLA/platforms/odla_popart/test/CMakeLists.txt
@@ -28,7 +28,7 @@ function(add_odla_cpp_unit_test name)
   set(target_name ${ARGV0})
 
   add_executable(${target_name} ${FILES} utils.cc)
-  target_link_libraries(${target_name} PUBLIC ODLA pthread gcov custom_ops odla_popart popart-only)
+  target_link_libraries(${target_name} PUBLIC ODLA pthread gcov custom_ops odla_popart popart)
 
   target_include_directories(${target_name}
       PRIVATE

--- a/tests/unittests/lit_cases/test_popart/test_pow_types_int32_int32_popart.cc
+++ b/tests/unittests/lit_cases/test_popart/test_pow_types_int32_int32_popart.cc
@@ -26,5 +26,4 @@
 // RUN: %t_popart.exe 0.0001 0 popart %data_path/test_pow_types_int32_int32 | FileCheck %s
 // CHECK: Result Pass
 // clang-format on
-// XFAIL: *
 #include "test_pow_types_int32_int32_popart.cc.tmp.main.cc.in"


### PR DESCRIPTION
This patch adds support for the newest poplar sdk on the following test setup.

Docker image:
    registry-intl.us-west-1.aliyuncs.com/computation/halo:0.8.1-devel-cuda11.4.2-cudnn8-centos7

SDK:
    poplar_sdk-centos_7_6-3.1.0-EA.1+1168-a2e17bf73e

Test command line:
    cmake -G Ninja .. -DHALO_USE_TIDY_CHECK=OFF -DHALO_GEN_DOCS=OFF -DPOPLAR_ROOT=$POPLAR_ROOT \
    -DPOPLAR_VERSION=$POPLAR_VERSION -DPOPART_ROOT=$POPART_ROOT -DODLA_BUILD_POPART_USE_CXX11ABI=ON \
     -DODLA_BUILD_POPART_CUSTOM_OPS=ON -DHALO_BUILD_RTLIB=OFF -DODLA_BUILD_TRT=OFF \
    -DODLA_BUILD_XNNPACK=OFF -DODLA_BUILD_EIGEN=OFF -DODLA_BUILD_DNNL=OFF \
    -DCMAKE_BUILD_TYPE=Debug -DODLA_BUILD_VODLA=off
    time ninja

Signed-off-by: Wei Xu <weix@graphcore.ai>