### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -127,8 +127,8 @@ jobs:
       - name: Prepare
         id: prepare
         run: |
-          echo "::set-output name=file::$(cd /tmp/download && ls HALO-*-ubuntu*.bz2)"
-          echo "::set-output name=date::$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          echo "file=$(cd /tmp/download && ls HALO-*-ubuntu*.bz2)" >> "$GITHUB_OUTPUT"
+          echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
           tag=latest
           if [[ $GITHUB_REF == refs/tags/Release/* ]]; then
             tag="Release-${GITHUB_REF#refs/tags/Release/}"
@@ -143,7 +143,7 @@ jobs:
             tag=pr-${{ github.event.number }}
           fi
           ls /tmp/download
-          echo ::set-output name=tag::${tag}
+          echo tag=${tag} >> "$GITHUB_OUTPUT"
 
       - name: Login to aliyun
         uses: docker/login-action@v1


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter